### PR TITLE
Changed artifact chksum verification

### DIFF
--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -93,7 +93,7 @@ class Resource(Descriptor):
         overwrite = False
         if os.path.exists(target):
             try:
-                self.__verify(target)
+                overwrite = not self.__verify(target)
             except Exception as ex:
                 logger.debug("Local resource verification failed")
                 overwrite = True
@@ -122,7 +122,8 @@ class Resource(Descriptor):
     def __verify(self, target):
         """ Checks all defined check_sums for an aritfact """
         if not self.checksums:
-            return True
+            logger.debug("Artifact '%s' lacks any checksum definition, it will be replaced" % self.name)
+            return False
         if not Resource.CHECK_INTEGRITY:
             logger.info("Integrity checking disabled, skipping verification.")
             return True

--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -23,7 +23,7 @@ the image build process.
 Artifacts section is meant exactly for this. *Cekit will automatically
 fetch any artifacts* specified in this section
 and check their consistency by computing checksum of
-the downloaded file and comparing it with the desired value.  The output name
+the downloaded file and comparing it with the desired value. The output name
 for downloaded resources will match the ``name`` attribute, which defaults to
 the base name of the file/URL. Artifact locations may be specified as ``url``\s,
 ``path``\s or ``git`` references.
@@ -49,7 +49,8 @@ the base name of the file/URL. Artifact locations may be specified as ``url``\s,
 
 .. note::
 
-    Currently supported algorithms are: md5, sha1 and sha256.
+    Currently supported algorithms are: md5, sha1 and sha256. If no algorithm is provided, artifact will
+    be fetched **every** time.
 
 For artifacts that are not publicly available Cekit provides a way to
 add a description detailing a location from which the artifact can be obtained.

--- a/tests/test_unit_resource.py
+++ b/tests/test_unit_resource.py
@@ -111,7 +111,9 @@ def test_fetching_file_exists_but_used_as_is(mocker):
     with open('file', 'w') as f:  # noqa: F841
         pass
     mock_urlopen = get_mock_urlopen(mocker)
-    res = Resource({'name': 'file', 'url': 'http:///dummy'})
+    res = Resource({'name': 'file',
+                    'url': 'http:///dummy',
+                    'md5': 'd41d8cd98f00b204e9800998ecf8427e'})
     res.copy()
     mock_urlopen.assert_not_called()
 
@@ -132,6 +134,25 @@ def test_fetching_file_exists_fetched_again(mocker):
         # Checksum will fail, because the "downloaded" file
         # will not have md5 equal to 123456. We need investigate
         # mocking of requests get calls to do it properly
+        res.copy()
+    mock_urlopen.assert_called_with('http:///dummy', context=ctx)
+
+
+def test_fetching_file_exists_no_hash_fetched_again(mocker):
+    """
+    It should download the file again, because available
+    file locally doesn't match checksum.
+    """
+    mock_urlopen = get_mock_urlopen(mocker)
+    ctx = get_ctx(mocker)
+    get_mock_ssl(mocker, ctx)
+
+    with open('file', 'w') as f:  # noqa: F841
+        pass
+    res = Resource({'name': 'file', 'url': 'http:///dummy'})
+    with pytest.raises(CekitError):
+        # url is not valid so we get error, but we are not interested
+        # in it. We just need to check that we attempted to downlad.
         res.copy()
     mock_urlopen.assert_called_with('http:///dummy', context=ctx)
 


### PR DESCRIPTION
If you don't specify any chksum for an artifact its integrity can't
be checked so we will consider it dirty and will fetch it again.