### PR TITLE
Implemented basic buildah support

### DIFF
--- a/cekit/builder.py
+++ b/cekit/builder.py
@@ -23,6 +23,9 @@ class Builder(object):
                 # import is delayed until here to prevent circular import error
                 from cekit.builders.osbs import OSBSBuilder as BuilderImpl
                 logger.info("Using OSBS builder to build the image.")
+            elif 'buildah' == build_engine:
+                from cekit.builders.buildah import BuildahBuilder as BuilderImpl
+                logger.info("Using Buildah builder to build the image.")
             else:
                 raise CekitError("Builder engine %s is not supported" % build_engine)
 

--- a/cekit/builders/buildah.py
+++ b/cekit/builders/buildah.py
@@ -1,0 +1,57 @@
+import logging
+import subprocess
+import os
+
+from cekit.builder import Builder
+from cekit.errors import CekitError
+
+
+logger = logging.getLogger('cekit')
+
+
+class BuildahBuilder(Builder):
+    """This class representes buildah builder in build-using-dockerfile mode."""
+
+    def __init__(self, build_engine, target, params={}):
+        self._tags = params.get('tags')
+        self._pull = params.get('pull', False)  # --pull-always
+        super(BuildahBuilder, self).__init__(build_engine, target, params)
+
+    def check_prerequisities(self):
+        try:
+            subprocess.check_output(['sudo', 'buildah', 'version'], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as ex:
+            raise CekitError("Buildah build engine needs buildah"
+                             " installed and configured, error: %s"
+                             % ex.output)
+        except Exception as ex:
+            raise CekitError("Buildah build engine needs buildah installed and configured!", ex)
+
+    def build(self):
+        """Build container image using buildah."""
+        tags = self._tags
+        cmd = ["sudo", "buildah", "build-using-dockerfile"]
+
+        if self._pull:
+            cmd.append('--pull-awlays')
+
+        # Custom tags for the container image
+        logger.debug("Building image with tags: '%s'" %
+                     "', '".join(tags))
+
+        for tag in tags:
+            cmd.extend(["-t", tag])
+
+        logger.info("Building container image...")
+
+        cmd.append(os.path.join(self.target, 'image'))
+
+        logger.debug("Running Buildah build: '%s'" % " ".join(cmd))
+
+        try:
+            subprocess.check_call(cmd)
+
+            logger.info("Image built and available under following tags: %s"
+                        % ", ".join(tags))
+        except:
+            raise CekitError("Image build failed, see logs above.")

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -67,7 +67,7 @@ class Cekit(object):
 
         build_group.add_argument('--build-engine',
                                  default='docker',
-                                 choices=['docker', 'osbs'],
+                                 choices=['docker', 'osbs', 'buildah'],
                                  help='an engine used to build the image.')
 
         build_group.add_argument('--build-tag',

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -5,6 +5,7 @@ Cekit supports following builder engines:
 
 * ``Docker`` -- build the container image using `docker build <https://docs.docker.com/engine/reference/commandline/build/>`_ command and it default option
 * ``OSBS`` -- build the container image using `OSBS service <https://osbs.readthedocs.io>`_
+* ``Buildah`` -- build the container image using `Buildah <https://github.com/projectatomic/buildah>`_
 
 Executing builds
 -----------------
@@ -18,7 +19,7 @@ You can execute an container image build by running:
 **Options affecting builder:**
 
 * ``--tag`` -- an image tag used to build image (can be specified multiple times)
-* ``--build-engine`` -- a builder engine to use ``osbs`` or ``docker`` [#f1]_
+* ``--build-engine`` -- a builder engine to use ``osbs``, ``buildah`` or ``docker`` [#f1]_
 * ``--build-pull`` -- ask a builder engine to check and fetch latest base image
 * ``--build-osbs-stage`` -- use ``rhpkg-stage`` tool instead of ``rhpkg``
 * ``--build-osbs-release`` [#f2]_ -- perform a OSBS release build
@@ -46,7 +47,7 @@ This is the default way to build an container image. The image is build using ``
 OSBS build
 ^^^^^^^^^^^^^^^
 
-This build is using ``rhpkg container-build`` to build the image using OSBS service. By default
+This build engine is using ``rhpkg container-build`` to build the image using OSBS service. By default
 it performs scratch build. If you need a release build you need to specify ``--build-osbs-release`` parameter.
 
 **Example:** Performing scratch build
@@ -61,3 +62,21 @@ it performs scratch build. If you need a release build you need to specify ``--b
 .. code:: bash
 
 	  $ cekit build --build-engine=osbs --build-osbs-release
+
+
+Buildah build
+^^^^^^^^^^^^^
+
+This build engine is based on `Buildah <https://github.com/projectatomic/buildah>`_. Buildah still doesn't
+support non-privileged builds so you need to have **sudo** configured to run `buildah` as a root user on
+your desktop.
+
+.. note::
+   If you need to use any non default registry, please update `/etc/containers/registry.conf` file.
+
+
+**Example:** Building image using Buildah
+
+.. code:: bash
+
+	  $ cekit build --build-engine=buildah

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -116,3 +116,32 @@ def test_docker_builder_run(mocker):
     builder.build()
 
     check_call.assert_called_once_with(['docker', 'build', '-t', 'foo', '-t', 'bar', 'tmp/image'])
+
+
+def test_buildah_builder_run(mocker):
+    params = {'tags': ['foo', 'bar']}
+    check_call = mocker.patch.object(subprocess, 'check_call')
+    builder = create_osbs_build_object(mocker, 'buildah', params)
+    builder.build()
+
+    check_call.assert_called_once_with(['sudo',
+                                        'buildah',
+                                        'build-using-dockerfile',
+                                        '-t', 'foo',
+                                        '-t', 'bar',
+                                        'tmp/image'])
+
+
+def test_buildah_builder_run_pull(mocker):
+    params = {'tags': ['foo', 'bar'], 'pull': True}
+    check_call = mocker.patch.object(subprocess, 'check_call')
+    builder = create_osbs_build_object(mocker, 'buildah', params)
+    builder.build()
+
+    check_call.assert_called_once_with(['sudo',
+                                        'buildah',
+                                        'build-using-dockerfile',
+                                        '--pull-awlays',
+                                        '-t', 'foo',
+                                        '-t', 'bar',
+                                        'tmp/image'])

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -36,7 +36,8 @@ def test_args_build_pull(mocker):
 
     assert Cekit().parse().args.build_pull
 
-@pytest.mark.parametrize('engine', ['osbs', 'docker'])
+
+@pytest.mark.parametrize('engine', ['osbs', 'docker', 'buildah'])
 def test_args_build_engine(mocker, engine):
     mocker.patch.object(sys, 'argv', ['cekit', 'build', '--build-engine', engine])
 


### PR DESCRIPTION
--build-engine now accepts buildah as a builder. You need to have
  buildah installed and sudo configure to run buildah as a root on you
  computer.