### PR TITLE
Run validation tests only if CEKIT_TEST_VALIDATE env is set.

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -8,6 +8,10 @@ import pytest
 from cekit.builders.osbs import Chdir
 from cekit.cli import Cekit
 
+pytestmark = pytest.mark.skipif('CEKIT_TEST_VALIDATE' not in os.environ, reason="Tests require "
+                                "Docker installed, export 'CEKIT_TEST_VALIDATE=y' variable if "
+                                "you need to run them.")
+
 
 def setup_function():
     """Reload cekit.module to make sure it doesnt contain old modules instances"""

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27,py35
 
 [testenv]
 passenv=
+  CEKIT_TEST_VALIDATE
   DOCKER_*
 deps=
   behave


### PR DESCRIPTION
These tests need Docker properly installed and configured and this
is causing troubles on some CI.
To enable these tests run
``` bash
export CEKIT_TEST_VALIDATE=y
make
```
in the Cekit project root.