### PR TITLE
Implemented --work-dir option switch

### DIFF
--- a/bash_completion/cekit
+++ b/bash_completion/cekit
@@ -7,6 +7,7 @@ _cekit_global_options()
     options+='--overrides '
     options+='--target '
     options+='--descriptor '
+    options+='--work-dir '
     echo "$options"
 }
 
@@ -50,6 +51,10 @@ _cekit_complete()
 	return
 
     elif [[ '--target' == $prev ]]; then
+	_filedir -d
+	return
+
+    elif [[ '--work-dir' == $prev ]]; then
 	_filedir -d
 	return
 

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -54,6 +54,11 @@ class Cekit(object):
                             action='store_true',
                             help='Set default options for Red Hat internal infrasructure.')
 
+        parser.add_argument('--work-dir',
+                            dest='work_dir',
+                            help="Location of cekit working directory, it's "
+                            "used to store dist-git repos.")
+
         test_group = parser.add_argument_group('test',
                                                "Arguments valid for the 'test' target")
 
@@ -165,6 +170,8 @@ class Cekit(object):
 
             if self.args.redhat:
                 tools.cfg['common']['redhat'] = True
+            if self.args.work_dir:
+                tools.cfg['common']['work_dir'] = self.args.work_dir
 
             # We need to construct Generator first, because we need overrides
             # merged in

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -20,6 +20,7 @@ You can execute an container image build by running:
 
 * ``--tag`` -- an image tag used to build image (can be specified multiple times)
 * ``--redhat`` -- build image using Red Hat defaults. See :ref:`Configuration section for Red Hat specific options<redhat_config>` for additional details.
+* ``--work-dir`` -- sets Cekit works directory where dist_git repositories are cloned into See :ref:`Configuration section for work_dir<workdir_config>`
 * ``--build-engine`` -- a builder engine to use ``osbs``, ``buildah`` or ``docker`` [#f1]_
 * ``--build-pull`` -- ask a builder engine to check and fetch latest base image
 * ``--build-osbs-stage`` -- use ``rhpkg-stage`` tool instead of ``rhpkg``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -18,11 +18,19 @@ Below you can find description of available sections together with options descr
 ``common``
 ------------
 
+.. _workdir_config:
+
 ``work_dir``
 ^^^^^^^^^^^^
 
 Contains location of Cekit working directory, which is used to store some persistent data like
 dist_git repositories.
+
+.. code:: yaml
+
+    [common]
+    work_dir=/tmp
+
 
 ``ssl_verify``
 ^^^^^^^^^^^^^^

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -81,6 +81,15 @@ def test_args_config_default(mocker):
     assert Cekit().parse().args.config == '~/.cekit/config'
 
 
+def test_args_workd_dir(mocker):
+    mocker.patch.object(sys, 'argv', ['cekit',
+                                      'generate',
+                                      '--work-dir',
+                                      'foo'])
+
+    assert Cekit().parse().args.work_dir == 'foo'
+
+
 def test_args_config(mocker):
     mocker.patch.object(sys, 'argv', ['cekit',
                                       '--config',


### PR DESCRIPTION
Common section configuration option 'work_dir' can now be overriden
via --work-dir command lines option

Fixes #223 