### PR TITLE
Fix a typo

### DIFF
--- a/cekit/builders/buildah.py
+++ b/cekit/builders/buildah.py
@@ -33,7 +33,7 @@ class BuildahBuilder(Builder):
         cmd = ["sudo", "buildah", "build-using-dockerfile"]
 
         if self._pull:
-            cmd.append('--pull-awlays')
+            cmd.append('--pull-always')
 
         # Custom tags for the container image
         logger.debug("Building image with tags: '%s'" %

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -164,7 +164,7 @@ def test_buildah_builder_run_pull(mocker):
     check_call.assert_called_once_with(['sudo',
                                         'buildah',
                                         'build-using-dockerfile',
-                                        '--pull-awlays',
+                                        '--pull-always',
                                         '-t', 'foo',
                                         '-t', 'bar',
                                         'tmp/image'])


### PR DESCRIPTION
When invoking buildah with _pull=True, use the --pull-always option.