### PR TITLE
Fix __eq__ method on ExecuteContainer to compare only proper classes

### DIFF
--- a/cekit/descriptor/execute.py
+++ b/cekit/descriptor/execute.py
@@ -72,6 +72,8 @@ class ExecuteContainer(Descriptor):
                 self._descriptor.insert(pos, executes)
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
         for i, execute in enumerate(self._descriptor):
             if execute != other[i]:
                 return False


### PR DESCRIPTION
Make sure that ExecuteContainer works even with old RHEL PyYAML which
is doing marchaling differently.