### PR TITLE
Implemented overrides chaining

### DIFF
--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -125,9 +125,11 @@ class Cekit(object):
         overrides_group = parser.add_mutually_exclusive_group()
 
         overrides_group.add_argument('--overrides',
+                                     action='append',
                                      help='a YAML object to override image descriptor')
 
         overrides_group.add_argument('--overrides-file',
+                                     action='append',
                                      dest='overrides',
                                      help='path to a file containing overrides')
 

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -56,7 +56,10 @@ class Generator(object):
         self._fetch_repos = False
 
         if overrides:
-            self.image = self.override(overrides)
+            # overrides must be processed in reversed order for overriding to work,
+            # our merge mechanism is designed to work top-down
+            for override in reversed(overrides):
+                self.image = self.override(override)
 
         logger.info("Initializing image descriptor...")
 

--- a/docs/overrides.rst
+++ b/docs/overrides.rst
@@ -16,9 +16,18 @@ To use an override descriptor you need to pass ``--overides-file`` argument to a
 
 .. code:: bash
 
-	  $ cekit build --overrides "{'labels': [{'name': 'foo', 'value': 'overriden'}]}"
+	  $ cekit build --overrides "{'labels': [{'name': 'foo', 'value': 'overridden'}]}"
 
+Overrides Chaining
+------------------
 
+You can even specify multiple overrides. They are resolved in order they appear on command line. This means that values from *first override specified overrides all values from later overrides*.
+
+**Example**: If you run following command, label `foo` will be set to `bar`.
+
+.. code:: bash
+
+	  $ cekit build --overrides "{'labels': [{'name': 'foo', 'value': 'bar'}]} --overrides "{'labels': [{'name': 'foo', 'value': 'baz'}]}"
 
 How overrides works
 -------------------

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -144,7 +144,7 @@ def test_args_overrides(mocker):
                                       '--overrides',
                                       'foo'])
 
-    assert Cekit().parse().args.overrides == 'foo'
+    assert Cekit().parse().args.overrides == ['foo']
 
 
 def test_args_overrides_file(mocker):
@@ -153,7 +153,7 @@ def test_args_overrides_file(mocker):
                                       '--overrides-file',
                                       'foo'])
 
-    assert Cekit().parse().args.overrides == 'foo'
+    assert Cekit().parse().args.overrides == ['foo']
 
 
 def test_args_overrides_exclusiver(mocker):


### PR DESCRIPTION
Cekit now accepts multiple overrides via command line options both
--overrides and --overrides-file can be chained together.

Overrides are resolved in order they appear so values from the
override which appeared first take precedence to later ones.