### PR TITLE
[CLOUD-2698] add usage: label to image schema

### DIFF
--- a/cekit/descriptor/image.py
+++ b/cekit/descriptor/image.py
@@ -13,6 +13,7 @@ map:
   schema_version: {type: int}
   release: {type: text}
   from: {type: str}
+  usage: {type: text}
   description: {type: text}
   labels: {type: any}
   envs:  {type: any}


### PR DESCRIPTION
usage: label has turned up in our base images and we need to be able
to override it.

https://issues.jboss.org/browse/CLOUD-2698