### PR TITLE
Container help pages

### DIFF
--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -192,16 +192,15 @@ class Cekit(object):
             tools.cfg['common']['redhat'] = True
         if self.args.work_dir:
             tools.cfg['common']['work_dir'] = self.args.work_dir
+
+        addhelp = tools.cfg.get('doc',{}).get('addhelp', False)
         if bool == type(self.args.addhelp):
-            tools.cfg['common']['addhelp'] = self.args.addhelp
-        else: # NoneType
-            if not 'addhelp' in tools.cfg['common']:
-                tools.cfg['common']['addhelp'] = False
+            addhelp = self.args.addhelp
 
         # We need to construct Generator first, because we need overrides
         # merged in
         params = {
-            'addhelp': tools.cfg['common']['addhelp'],
+            'addhelp': addhelp,
             'redhat':  tools.cfg['common']['redhat'],
         }
         self.generator = Generator(self.args.descriptor,

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -141,6 +141,20 @@ class Cekit(object):
                             default="image.yaml",
                             help="path to image descriptor file, default: image.yaml")
 
+        addhelp_group = parser.add_mutually_exclusive_group()
+
+        addhelp_group.add_argument('--add-help',
+                                   dest='addhelp',
+                                   action='store_const',
+                                   const=True,
+                                   help="Include generate help files in the image")
+
+        addhelp_group.add_argument('--no-add-help',
+                                   dest='addhelp',
+                                   action='store_const',
+                                   const=False,
+                                   help="Do not include generate help files in the image")
+
         parser.add_argument('commands',
                             nargs='+',
                             choices=['generate', 'build', 'test'],
@@ -178,10 +192,18 @@ class Cekit(object):
             tools.cfg['common']['redhat'] = True
         if self.args.work_dir:
             tools.cfg['common']['work_dir'] = self.args.work_dir
+        if bool == type(self.args.addhelp):
+            tools.cfg['common']['addhelp'] = self.args.addhelp
+        else: # NoneType
+            if not 'addhelp' in tools.cfg['common']:
+                tools.cfg['common']['addhelp'] = False
 
         # We need to construct Generator first, because we need overrides
         # merged in
-        params = {'redhat': tools.cfg['common']['redhat']}
+        params = {
+            'addhelp': tools.cfg['common']['addhelp'],
+            'redhat':  tools.cfg['common']['redhat'],
+        }
         self.generator = Generator(self.args.descriptor,
                                    self.args.target,
                                    self.args.build_engine,

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -203,6 +203,10 @@ class Cekit(object):
             'addhelp': addhelp,
             'redhat':  tools.cfg['common']['redhat'],
         }
+
+        if 'help_template' in tools.cfg.get('doc',{}):
+            params['help_template'] = tools.cfg['doc']['help_template']
+
         self.generator = Generator(self.args.descriptor,
                                    self.args.target,
                                    self.args.build_engine,

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -160,6 +160,7 @@ class Generator(object):
         loader = FileSystemLoader(os.path.dirname(template_file))
         env = Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
         env.globals['helper'] = TemplateHelper()
+        env.globals['addhelp'] = self._params.get('addhelp')
         template = env.get_template(os.path.basename(template_file))
 
         dockerfile = os.path.join(self.target,

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -174,11 +174,20 @@ class Generator(object):
                 self.image).encode('utf-8'))
         logger.debug("Dockerfile rendered")
 
-        template_file = os.path.join(os.path.dirname(__file__),
-                                     '..',
-                                     'templates',
-                                     'help.jinja')
-        help_template = env.get_template(os.path.basename(template_file))
+        if 'help_template' in self._params:
+            help_template_path = self._params['help_template']
+        else:
+            help_template_path = os.path.join(os.path.dirname(__file__),
+                                              '..',
+                                              'templates',
+                                              'help.jinja')
+
+        help_dirname, help_basename = os.path.split(help_template_path)
+        loader = FileSystemLoader(help_dirname)
+        env = Environment(loader=loader, trim_blocks=True, lstrip_blocks=True)
+        env.globals['helper'] = TemplateHelper()
+        help_template = env.get_template(help_basename)
+
         helpfile = os.path.join(self.target, 'image', 'help.md')
         with open(helpfile, 'wb') as f:
             f.write(help_template.render(

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -173,6 +173,17 @@ class Generator(object):
                 self.image).encode('utf-8'))
         logger.debug("Dockerfile rendered")
 
+        template_file = os.path.join(os.path.dirname(__file__),
+                                     '..',
+                                     'templates',
+                                     'help.jinja')
+        help_template = env.get_template(os.path.basename(template_file))
+        helpfile = os.path.join(self.target, 'image', 'help.md')
+        with open(helpfile, 'wb') as f:
+            f.write(help_template.render(
+                self.image).encode('utf-8'))
+        logger.debug("help.md rendered")
+
     def prepare_repositories(self):
         """ Prepare repositories for build time injection. """
         if 'packages' not in self.image:

--- a/cekit/templates/help.jinja
+++ b/cekit/templates/help.jinja
@@ -1,0 +1,68 @@
+# {{ name }}
+
+## Description
+
+{{ description }}
+
+{% if usage %}
+## Usage
+
+{{ usage }}
+{% endif %}
+
+{% if envs %}
+## Environment variables
+
+### Informational
+
+These environment variables are defined in the image.
+
+{% for env in helper.envs(envs)|sort(attribute='name') %}
+__{{ env.name }}__
+>"{{ env.value }}"
+
+{% endfor %}
+
+### Configuration
+
+The image can be configured by defining these environment variables
+when starting a container:
+
+{% for env in envs|sort(attribute='name') %}{% if env.description or env.example %}
+__{{ env.name }}__
+{% if env.description %}> {{ env.description }}<br />
+{% endif %}
+{% if env.example %}> _Example: {{ env.example }}_
+{% endif %}
+
+{% endif %}{% endfor %}
+
+{% endif %}
+
+{% if labels %}
+## Labels
+
+{% for label in labels|sort(attribute='name') %}
+__{{ label.name }}__
+> {{ label.value }}
+
+{% endfor %}
+{% endif %}
+
+{% if 'root' == run['user'] or ports %}
+## Security implications
+
+{% if 'root' == run['user'] %}
+__Root privileges__
+> The container runs as root.
+
+{% endif %}
+
+{% if ports %}
+### Published Ports
+
+{% for port in helper.ports(ports) %}
+ * {{ port }}
+{% endfor %}
+{% endif %}
+{% endif %}

--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -130,3 +130,7 @@ ENTRYPOINT {{ helper.cmd(run['entrypoint']) }}
 CMD {{ helper.cmd(run['cmd']) }}
 {% endif %}
 {% endif %}
+
+{% if addhelp %}
+ADD help.md /
+{% endif %}

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -28,8 +28,8 @@ def get_cfg(config_path):
     cfg['common'] = cfg.get('common', {})
     cfg['common']['work_dir'] = cfg.get('common').get('work_dir', '~/.cekit')
     cfg['common']['redhat'] = cfg.get('common', {}).get('redhat', False)
-    if cp.has_option('common', 'addhelp'):
-        cfg['common']['addhelp'] = cp.getboolean('common', 'addhelp')
+    if 'doc' in cp and cp.has_option('doc', 'addhelp'):
+        cfg['doc']['addhelp'] = cp.getboolean('doc', 'addhelp')
     return cfg
 
 

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -28,7 +28,7 @@ def get_cfg(config_path):
     cfg['common'] = cfg.get('common', {})
     cfg['common']['work_dir'] = cfg.get('common').get('work_dir', '~/.cekit')
     cfg['common']['redhat'] = cfg.get('common', {}).get('redhat', False)
-    if 'doc' in cp and cp.has_option('doc', 'addhelp'):
+    if cp.has_section('doc') and cp.has_option('doc', 'addhelp'):
         cfg['doc']['addhelp'] = cp.getboolean('doc', 'addhelp')
     return cfg
 

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -28,6 +28,8 @@ def get_cfg(config_path):
     cfg['common'] = cfg.get('common', {})
     cfg['common']['work_dir'] = cfg.get('common').get('work_dir', '~/.cekit')
     cfg['common']['redhat'] = cfg.get('common', {}).get('redhat', False)
+    if cp.has_option('common', 'addhelp'):
+        cfg['common']['addhelp'] = cp.getboolean('common', 'addhelp')
     return cfg
 
 

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -20,6 +20,8 @@ You can execute an container image build by running:
 
 * ``--tag`` -- an image tag used to build image (can be specified multiple times)
 * ``--redhat`` -- build image using Red Hat defaults. See :ref:`Configuration section for Red Hat specific options<redhat_env>` for additional details.
+* `--add-help`` -- add generated `help.md` file to the image
+* `--no-add-help`` -- don't add generated `help.md` file to the image
 * ``--work-dir`` -- sets Cekit works directory where dist_git repositories are cloned into See :ref:`Configuration section for work_dir<workdir_config>`
 * ``--build-engine`` -- a builder engine to use ``osbs``, ``buildah`` or ``docker`` [#f1]_
 * ``--build-pull`` -- ask a builder engine to check and fetch latest base image

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -107,3 +107,15 @@ This option changes Cekit default options to comply with Red Hat internal infras
 .. note::
 
    If you are using Cekit within Red Hat infrastructure you should have valid Kerberos ticket.
+
+``addhelp``
+^^^^^^^^^^
+This option instructs Cekit to install the generated `help.md` file into the generate image
+sources. The file is inserted at the root path (`/`). The default value is False.
+
+**Example**: To enable this flag add following lines into your ``~/.cekit/config`` file:
+
+.. code::
+
+   [common]
+   addhelp = true

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -108,6 +108,11 @@ This option changes Cekit default options to comply with Red Hat internal infras
 
    If you are using Cekit within Red Hat infrastructure you should have valid Kerberos ticket.
 
+``doc``
+-------
+
+This section collects together configuration options relating to documentation.
+
 ``addhelp``
 ^^^^^^^^^^
 This option instructs Cekit to install the generated `help.md` file into the generate image
@@ -117,5 +122,17 @@ sources. The file is inserted at the root path (`/`). The default value is False
 
 .. code::
 
-   [common]
+   [doc]
    addhelp = true
+
+``help_template``
+^^^^^^^^^^^^^^^^^
+
+This option overrides the default Jinja template used in the generation of `help.md` files.
+
+**Example**:
+
+.. code::
+
+   [doc]
+   help_template = /home/jon/something/my_help.md

--- a/tests/test_addhelp.py
+++ b/tests/test_addhelp.py
@@ -56,12 +56,12 @@ def test_confNone_cmdlineNone(mocker, workdir, tmpdir):
     assert False == run_cekit(workdir)
 
 def test_confFalse_cmdlineNone(mocker, workdir, tmpdir):
-    config = setup_config(tmpdir, "[common]\naddhelp = False")
+    config = setup_config(tmpdir, "[doc]\naddhelp = False")
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, 'generate'])
     assert False == run_cekit(workdir)
 
 def test_confTrue_cmdlineNone(mocker, workdir, tmpdir):
-    config = setup_config(tmpdir, "[common]\naddhelp = True")
+    config = setup_config(tmpdir, "[doc]\naddhelp = True")
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, 'generate'])
     assert True == run_cekit(workdir)
 
@@ -71,12 +71,12 @@ def test_confNone_cmdlineTrue(mocker, workdir, tmpdir):
     assert True == run_cekit(workdir)
 
 def test_confFalse_cmdlineTrue(mocker, workdir, tmpdir):
-    config = setup_config(tmpdir, "[common]\naddhelp = False")
+    config = setup_config(tmpdir, "[doc]\naddhelp = False")
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--add-help', 'generate'])
     assert True == run_cekit(workdir)
 
 def test_confTrue_cmdlineTrue(mocker, workdir, tmpdir):
-    config = setup_config(tmpdir, "[common]\naddhelp = True")
+    config = setup_config(tmpdir, "[doc]\naddhelp = True")
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--add-help', 'generate'])
     assert True == run_cekit(workdir)
 
@@ -86,11 +86,11 @@ def test_confNone_cmdlineFalse(mocker, workdir, tmpdir):
     assert False == run_cekit(workdir)
 
 def test_confFalse_cmdlineFalse(mocker, workdir, tmpdir):
-    config = setup_config(tmpdir, "[common]\naddhelp = False")
+    config = setup_config(tmpdir, "[doc]\naddhelp = False")
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--no-add-help', 'generate'])
     assert False == run_cekit(workdir)
 
 def test_confTrue_cmdlineFalse(mocker, workdir, tmpdir):
-    config = setup_config(tmpdir, "[common]\naddhelp = True")
+    config = setup_config(tmpdir, "[doc]\naddhelp = True")
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--no-add-help', 'generate'])
     assert False == run_cekit(workdir)

--- a/tests/test_addhelp.py
+++ b/tests/test_addhelp.py
@@ -1,0 +1,96 @@
+# test the "addhelp" feature
+# we need to test cartesian product of:
+#   cekit config {no addhelp, addhelp=True, addhelp=False}
+#   cmdline      {nothing, --add-help, --no-add-help})
+
+import os
+import sys
+import yaml
+import pytest
+from cekit.builders.osbs import Chdir
+from cekit.cli import Cekit
+
+image_descriptor = {
+    'schema_version': 1,
+    'from': 'centos:latest',
+    'name': 'test/image',
+    'version': '1.0',
+    'labels': [{'name': 'foo', 'value': 'bar'}, {'name': 'labela', 'value': 'a'}],
+    'envs': [{'name': 'baz', 'value': 'qux'}, {'name': 'enva', 'value': 'a'}],
+    'run': {'cmd': ['sleep', '60']},
+}
+
+@pytest.fixture(scope="module")
+def workdir(tmpdir_factory):
+    tdir = str(tmpdir_factory.mktemp("image"))
+    with open(os.path.join(tdir, 'image.yaml'), 'w') as fd:
+        yaml.dump(image_descriptor, fd, default_flow_style=False)
+    return tdir
+    # XXX cleanup?
+
+def run_cekit(cwd):
+    with Chdir(cwd):
+        c = Cekit().parse()
+        c.configure()
+        return c.generator._params['addhelp']
+
+def setup_config(tmpdir, contents):
+    p = str(tmpdir.join("config"))
+    with open(p, 'w') as fd:
+        fd.write(contents)
+    return p
+
+def test_addhelp_mutex_cmdline(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, '')
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--add-help', '--no-add-help', 'generate'])
+    with pytest.raises(SystemExit):
+        run_cekit(workdir)
+
+# test method naming scheme:
+#   test_confX_cmdlineY where {X,Y} ∈ {None,True,False}
+# XXX: would be nicer to dynamically generate these
+
+def test_confNone_cmdlineNone(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, '')
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, 'generate'])
+    assert False == run_cekit(workdir)
+
+def test_confFalse_cmdlineNone(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, "[common]\naddhelp = False")
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, 'generate'])
+    assert False == run_cekit(workdir)
+
+def test_confTrue_cmdlineNone(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, "[common]\naddhelp = True")
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, 'generate'])
+    assert True == run_cekit(workdir)
+
+def test_confNone_cmdlineTrue(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, '')
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--add-help', 'generate'])
+    assert True == run_cekit(workdir)
+
+def test_confFalse_cmdlineTrue(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, "[common]\naddhelp = False")
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--add-help', 'generate'])
+    assert True == run_cekit(workdir)
+
+def test_confTrue_cmdlineTrue(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, "[common]\naddhelp = True")
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--add-help', 'generate'])
+    assert True == run_cekit(workdir)
+
+def test_confNone_cmdlineFalse(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, '')
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--no-add-help', 'generate'])
+    assert False == run_cekit(workdir)
+
+def test_confFalse_cmdlineFalse(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, "[common]\naddhelp = False")
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--no-add-help', 'generate'])
+    assert False == run_cekit(workdir)
+
+def test_confTrue_cmdlineFalse(mocker, workdir, tmpdir):
+    config = setup_config(tmpdir, "[common]\naddhelp = True")
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--no-add-help', 'generate'])
+    assert False == run_cekit(workdir)

--- a/tests/test_addhelp.py
+++ b/tests/test_addhelp.py
@@ -1,4 +1,5 @@
 # test the "addhelp" feature
+# -*- encoding: utf-8 -*-
 # we need to test cartesian product of:
 #   cekit config {no addhelp, addhelp=True, addhelp=False}
 #   cmdline      {nothing, --add-help, --no-add-help})
@@ -43,8 +44,9 @@ def setup_config(tmpdir, contents):
 def test_addhelp_mutex_cmdline(mocker, workdir, tmpdir):
     config = setup_config(tmpdir, '')
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, '--add-help', '--no-add-help', 'generate'])
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as excinfo:
         run_cekit(workdir)
+    assert 0 != excinfo.value.code
 
 # test method naming scheme:
 #   test_confX_cmdlineY where {X,Y} ∈ {None,True,False}


### PR DESCRIPTION
This is a bit WIP still but raising PR for feedback. My own list of things still todo

 - [x] <s>should we always generate help.md? Or make it toggleable. If so, default to on?</s>flag/config option to include generate docs in image
   - [x] + key in ~/.cekit config
 - [x] document the help.md generation in cekit's docs
 - [x] <s>intersection with usage label? if usage label is not present, should we add a label pointing at the location of the help.md in the image?</s> punt
 - [x] <s>markdown or asciidoc? for asciidoc, we could use tables for some things (similar to our old autogenerated docs). But are there plans for other systems to consume these pages, and if so, what would they accept?</s> markdown for now
 - [ ] support user-provided template file...
    - [x] specified in config file
    - [ ] specified on command line?
    - [ ] specified in image yaml
 - [x] (determine and write) relevant tests

Example of output docs: https://github.com/jmtd/redhat-openjdk-18-openshift-image/blob/help-pages/target/image/help.md