### PR TITLE
Remove --build-tag argument

### DIFF
--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -78,12 +78,6 @@ class Cekit(object):
                                  choices=['docker', 'osbs', 'buildah'],
                                  help='an engine used to build the image.')
 
-        build_group.add_argument('--build-tag',
-                                 dest='build_tags',
-                                 action='append',
-                                 help='tag to assign to the built image, '
-                                 'can be used multiple times')
-
         build_group.add_argument('--build-pull',
                                  dest='build_pull',
                                  action='store_true',
@@ -148,15 +142,6 @@ class Cekit(object):
                                 you can specify multiple commands")
 
         self.args = parser.parse_args()
-
-        # DEPRECATED - remove following lines and --build-tag option
-        if self.args.build_tags:
-            logger.warning("--build-tag is deprecated and will be removed in cekit 2.0,"
-                           " please use --tag instead.")
-            if not self.args.tags:
-                self.args.tags = self.args.build_tags
-            else:
-                self.args.tags += self.args.build_tags
 
         return self
 

--- a/completion/bash/cekit
+++ b/completion/bash/cekit
@@ -16,7 +16,6 @@ _cekit_build_options()
 {
     local options
     options+='--build-engine '
-    options+='--build-tag '
     options+='--build-pull '
     options+='--build-osbs-release '
     options+='--build-osbs-user '

--- a/completion/zsh/_cekit
+++ b/completion/zsh/_cekit
@@ -62,7 +62,6 @@ _cekit() {
 _cekit_build() {
     _arguments \
         "--build-engine[an engine used to build the image]" \
-        "*--build-tag[tag to assign to the built image, can be used multiple times]" \
         "--build-pull[Always fetch latest base image during build]" \
         "--build-osbs-release[execute OSBS release build]" \
         "--build-osbs-user[user for rphkg tool]" \

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -18,19 +18,6 @@ def test_args_not_valid_command(mocker):
         Cekit().parse()
 
 
-@pytest.mark.parametrize('tags, build_tags, expected', [
-    (['foo'], ['bar'], ['foo', 'bar']),
-    ([], ['bar'], ['bar']),
-    (['foo'], [], ['foo']),
-    (['foo', 'bar'], ['baz', 'foe'], ['foo', 'bar', 'baz', 'foe'])])
-def test_args_tags(mocker, tags, build_tags, expected):
-    tags = sum([['--tag', t] for t in tags], [])
-    build_tags = sum([['--build-tag', t] for t in build_tags], [])
-
-    mocker.patch.object(sys, 'argv', ['cekit', 'generate'] + tags + build_tags)
-    assert Cekit().parse().args.tags == expected
-
-
 def test_args_build_pull(mocker):
     mocker.patch.object(sys, 'argv', ['cekit', 'build', '--build-pull'])
 


### PR DESCRIPTION
This was marked as deprecated and for removal in 2.0.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>