### PR TITLE
Support defining help_template in image.yaml

### DIFF
--- a/cekit/descriptor/image.py
+++ b/cekit/descriptor/image.py
@@ -22,7 +22,8 @@ map:
   modules: {type: any}
   packages: {type: any}
   osbs: {type: any}
-  volumes: {type: any}""")
+  volumes: {type: any}
+  help_template: {type: text}""")
 
 
 def get_image_schema():

--- a/cekit/descriptor/image.py
+++ b/cekit/descriptor/image.py
@@ -23,7 +23,9 @@ map:
   packages: {type: any}
   osbs: {type: any}
   volumes: {type: any}
-  help_template: {type: text}""")
+  help:
+    map:
+      template: {type: text}""")
 
 
 def get_image_schema():

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -174,10 +174,10 @@ class Generator(object):
                 self.image).encode('utf-8'))
         logger.debug("Dockerfile rendered")
 
-        if 'help_template' in self._params:
-            help_template_path = self._params['help_template']
-        elif 'help_template' in self.image:
+        if 'help_template' in self.image:
             help_template_path = self.image['help_template']
+        elif 'help_template' in self._params:
+            help_template_path = self._params['help_template']
         else:
             help_template_path = os.path.join(os.path.dirname(__file__),
                                               '..',

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -174,8 +174,8 @@ class Generator(object):
                 self.image).encode('utf-8'))
         logger.debug("Dockerfile rendered")
 
-        if 'help_template' in self.image:
-            help_template_path = self.image['help_template']
+        if self.image.get('help', {}).get('template', ""):
+            help_template_path = self.image['help']['template']
         elif 'help_template' in self._params:
             help_template_path = self._params['help_template']
         else:

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -176,6 +176,8 @@ class Generator(object):
 
         if 'help_template' in self._params:
             help_template_path = self._params['help_template']
+        elif 'help_template' in self.image:
+            help_template_path = self.image['help_template']
         else:
             help_template_path = os.path.join(os.path.dirname(__file__),
                                               '..',

--- a/docs/descriptor/help.rst
+++ b/docs/descriptor/help.rst
@@ -1,0 +1,17 @@
+
+help
+----
+
+The optional help sub-section defines a single key ``template``, which can be used
+to define a filename to use for generating image documentation at build time. By
+default, a template supplied within Cekit is used.
+
+At image build-time, the template is interpreted by the `Jinja2
+<http://jinja.pocoo.org/>`_ template engine.  For a concrete example, see the
+`default help.jinja supplied in the Cekit source code
+<https://github.com/cekit/cekit/blob/develop/cekit/templates/help.jinja>`_.
+
+.. code:: yaml
+
+  help:
+    template: myhelp.jinja

--- a/docs/descriptor/image.rst
+++ b/docs/descriptor/image.rst
@@ -8,6 +8,7 @@ Image descriptor contains all information Cekit needs to build and test a contai
 .. include:: version.rst
 .. include:: description.rst
 .. include:: from.rst
+.. include:: help.rst
 .. include:: envs.rst
 
 .. _labels:

--- a/docs/handbook.rst
+++ b/docs/handbook.rst
@@ -13,4 +13,5 @@ and be familiar with building and testing images with it.
     test
     local_development
     repository_management
+    image_help_pages
     redhat

--- a/docs/image_help_pages.rst
+++ b/docs/image_help_pages.rst
@@ -1,0 +1,55 @@
+.. _image_help_pages:
+
+Image Help Pages
+================
+
+At image build-time, Cekit generates a "help" documentation page, which is
+saved adjacent to the generate image sources. The help page can optionally be
+included into the image. The template used to generate the help page can be
+overridden by the user's configuration file, or the input image configuration,
+either via the central image.yaml file, included modules or overrides.
+
+Adding the help page to your image
+----------------------------------
+
+There are two ways to instruct Cekit to add the help page to your image: either
+Specify ``--add-help`` on the command-line when running the *build* phase, or
+via your configuration file, in the *doc* section:
+
+.. code::
+
+  [doc]
+  addhelp = true
+
+Providing your own help page template
+-------------------------------------
+
+The default help template is supplied within Cekit. You can override it for
+every image via your configuration, or on a per-image basis in the image
+definition.
+
+Via configuration
+^^^^^^^^^^^^^^^^^
+
+**Example**:
+
+.. code::
+
+   [doc]
+   help_template = /home/jon/something/my_help.md
+
+Via image definition
+^^^^^^^^^^^^^^^^^^^^
+
+This could be in the master ``image.yaml``, or in a module referenced from the
+``image.yaml``, or on the command-line via ``--overrides`` or
+``--overrides-file``:
+
+**Example**:
+
+.. code::
+
+   …
+   help:
+     template: /home/jon/something/my_help.md
+

--- a/tests/test_addhelp.py
+++ b/tests/test_addhelp.py
@@ -90,6 +90,29 @@ def test_no_override_help_template(mocker, workdir, tmpdir):
             sys.stderr.write("JMTD: {}\n".format(contents.find(template_teststr)))
             assert -1 == contents.find(template_teststr)
 
+def test_image_override_help_template(mocker, tmpdir):
+    help_template = os.path.join(str(tmpdir),"help.jinja")
+    with open(help_template, "w") as fd:
+        fd.write(template_teststr)
+
+    config = setup_config(tmpdir, "")
+    my_image_descriptor = image_descriptor.copy()
+    my_image_descriptor['help_template'] = help_template
+    mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, 'generate'])
+
+    with Chdir(str(tmpdir)):
+        with open('image.yaml', 'w') as fd:
+            yaml.dump(my_image_descriptor, fd, default_flow_style=False)
+        c = Cekit().parse()
+        c.configure()
+        try:
+            c.run()
+        except SystemExit:
+            pass
+        with open("target/image/help.md", "r") as fd:
+            contents = fd.read()
+            assert contents.find(template_teststr) >= 0
+
 # test method naming scheme:
 #   test_confX_cmdlineY where {X,Y} ∈ {None,True,False}
 # XXX: would be nicer to dynamically generate these

--- a/tests/test_addhelp.py
+++ b/tests/test_addhelp.py
@@ -100,7 +100,7 @@ def test_image_override_help_template(mocker, tmpdir):
 
     config = setup_config(tmpdir, "")
     my_image_descriptor = image_descriptor.copy()
-    my_image_descriptor['help_template'] = help_template
+    my_image_descriptor['help'] = {'template': help_template}
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, 'generate'])
 
     with Chdir(str(tmpdir)):
@@ -129,7 +129,7 @@ def test_image_override_config_help_template(mocker, tmpdir):
     with open(help_template2, "w") as fd:
         fd.write("2")
     my_image_descriptor = image_descriptor.copy()
-    my_image_descriptor['help_template'] = help_template2
+    my_image_descriptor['help'] = {'template': help_template2}
 
     mocker.patch.object(sys, 'argv', ['cekit', '-v', '--config', config, 'generate'])
 


### PR DESCRIPTION
I think this is likely to be the way this is most often used in
practice. An image author may wish to provide a custom help.md file,
potentially containing long-form static text, either directly in an
image.yaml, or indirectly via a module (perhaps to share with a
family of images).

<s>I've marked this WIP because I think the precedence should be

> defined in config < defined in image.yaml (post module processing) < defined on cmdline

But right now that's not how things are, config file trumps image.yaml,
and we haven't implemented command line argument for this at all.</s>
precedence fixed; let's not add a new cmdline argument, instead users could do `--overrides { help: template: foo.md }` or similar