### PR TITLE
io.openshift.expose-services only if ports defined

### DIFF
--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -166,7 +166,8 @@ class Generator(object):
                    'value': '%s' % self.image['version']}]
 
         # do not override this label if it's already set
-        if 'io.openshift.expose-services' not in [ k['name'] for k in self.image['labels'] ]:
+        if self.image.get('ports', []) and \
+            'io.openshift.expose-services' not in [ k['name'] for k in self.image['labels'] ]:
             labels.append({'name': 'io.openshift.expose-services',
                            'value': self._generate_expose_services()})
 

--- a/tests/test_expose_services.py
+++ b/tests/test_expose_services.py
@@ -67,13 +67,22 @@ def test_expose_services_label_not_generated_wo_redhat(mocker, workdir):
 
 def test_expose_services_label_generated(mocker, workdir):
     """Test to ensure that io.openshift.expose-services is auto-generated
-    if the --redhat argument is supplied."""
+    if the --redhat argument is supplied and ports are defined."""
 
     dockerfile = run_cekit_return_dockerfile(mocker, workdir,
         ['cekit', '-v', '--config', '/dev/null', '--redhat',
              '--overrides', '{ports: [{value: 8080}]}', 'generate'])
 
     assert dockerfile.find("io.openshift.expose-services") >= 0
+
+def test_expose_services_label_no_ports_not_generated(mocker, workdir):
+    """Test to ensure that io.openshift.expose-services is not auto-generated
+    if the --redhat argument is supplied but no ports are defined."""
+
+    dockerfile = run_cekit_return_dockerfile(mocker, workdir,
+        ['cekit', '-v', '--config', '/dev/null', '--redhat', 'generate'])
+
+    assert dockerfile.find("io.openshift.expose-services") < 0
 
 def test_expose_services_label_not_generated_without_expose(mocker, workdir):
     """Test to ensure that io.openshift.expose-services label does not


### PR DESCRIPTION
Only generate io.openshift.expose-services if there are ports
defined.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>