### PR TITLE
Ensure Module object has attribute before accessing it

### DIFF
--- a/cekit/module.py
+++ b/cekit/module.py
@@ -40,7 +40,7 @@ def copy_module_to_target(name, version, target):
                 check_module_version(dest, version)
 
             if not os.path.exists(dest):
-                logger.debug("Copying module '%s' to: '%s'" % (name, dest))
+                logger.debug("Copying module '%s' from '%s' to: '%s'" % (name, module.path, dest))
                 shutil.copytree(module.path, dest)
             return module
 
@@ -51,9 +51,9 @@ def check_module_version(path, version):
     descriptor = Module(tools.load_descriptor(os.path.join(path, 'module.yaml')),
                         path,
                         os.path.dirname(os.path.abspath(os.path.join(path, 'module.yaml'))))
-    if descriptor.version != version:
+    if hasattr(descriptor, 'version') and descriptor.version != version:
         raise CekitError("Requested conflicting version '%s' of module '%s'" %
-                             (version, descriptor['name']))
+                     (version, descriptor['name']))
 
 
 def get_dependencies(descriptor, base_dir):

--- a/tests/issue_322/image.yaml
+++ b/tests/issue_322/image.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+
+from: "rhel7"
+name: "testimage"
+version: "1.0"
+
+modules:
+  repositories:
+  - path: modules
+  install:
+  - name: a
+    version: "foo"
+  - name: b

--- a/tests/issue_322/modules/a/module.yaml
+++ b/tests/issue_322/modules/a/module.yaml
@@ -1,0 +1,3 @@
+schema_version: 1
+name: a
+version: "foo"

--- a/tests/issue_322/modules/b/module.yaml
+++ b/tests/issue_322/modules/b/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: b
+version: '1.0'
+
+modules:
+  install:
+  - name: c

--- a/tests/issue_322/modules/c/module.yaml
+++ b/tests/issue_322/modules/c/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: c
+version: '1.0'
+
+modules:
+  install:
+  - name: d

--- a/tests/issue_322/modules/d/module.yaml
+++ b/tests/issue_322/modules/d/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: d
+version: '1.0'
+
+modules:
+  install:
+  - name: a

--- a/tests/test_unit_module.py
+++ b/tests/test_unit_module.py
@@ -1,8 +1,10 @@
 import os
+import yaml
 
 from cekit.config import Config
 from cekit.descriptor import Module
 from cekit.module import modules
+from cekit.generator.base import Generator
 
 module_desc = {
     'schema_version': 1,
@@ -26,3 +28,18 @@ def test_modules_repos(tmpdir):
     module = Module(module_desc, os.getcwd(), '/tmp')
     module.fetch_dependencies(tmpdir)
     assert 'foo' in [m['name'] for m in modules]
+
+def test_issue_322(tmpdir):
+    """tests a particular inheritance issue reported as GitHub issue #322"""
+    target_dir = str(tmpdir.mkdir('target'))
+    artifact_dir = str(tmpdir.mkdir('artifacts'))
+    clone_dir = str(tmpdir.mkdir('clone'))
+
+    descriptor = yaml.load(open("tests/issue_322/image.yaml").read())
+    image = Module(descriptor=descriptor, path="tests/issue_322", artifact_dir=artifact_dir)
+    image.fetch_dependencies(clone_dir)
+
+    generator = Generator.__new__(Generator, descriptor_path="tests/issue_322", target=target_dir, builder="docker", overrides=None, params={})
+    generator.image = image
+    generator.target = target_dir
+    generator.prepare_modules()


### PR DESCRIPTION
Module objects may not have a 'version' attribute, so check that
it exists before trying to access it.

Fixes #322.