### PR TITLE
add newline at the end of string literal

### DIFF
--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -50,7 +50,8 @@ class Resource(Descriptor):
           sha1: {type: str}
           sha256: {type: str}
           description: {type: str}
-        assert: \"val['git'] is not None or val['path'] is not None or val['url] is not None\"""")]
+        assert: \"val['git'] is not None or val['path'] is not None or val['url] is not None\"
+        """)]
         super(Resource, self).__init__(descriptor)
         self.skip_merging = ['md5', 'sha1', 'sha256']
 


### PR DESCRIPTION
The adjoining \" and """ cause syntax-highlighter problems in Vim.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>