### PR TITLE
Fix KeyError when fetching the artifact

### DIFF
--- a/cekit/cache/artifact.py
+++ b/cekit/cache/artifact.py
@@ -78,7 +78,7 @@ class ArtifactCache():
     def _find_artifact(self, alg, chksum):
         cache = self._get_cache()
         for _, artifact in cache.items():
-            if artifact[alg] == chksum:
+            if alg in artifact and artifact[alg] == chksum:
                 return artifact
 
         raise CekitError('Artifact is not cached.')


### PR DESCRIPTION
In case we try to find an artifact by a specific alrorithm
and this algorithm is not computed for some artifacts
it will fail. Instead of failing, it should simply not return the
artifact.