### PR TITLE
Fix test output directory

### DIFF
--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -11,6 +11,7 @@ from cekit.config import Config
 from cekit.builder import Builder
 from cekit.descriptor.resource import _PlainResource
 from cekit.errors import CekitError
+from cekit.tools import Chdir
 
 logger = logging.getLogger('cekit')
 config = Config()
@@ -336,16 +337,3 @@ class DistGit(object):
             logger.info("Changes are not pushed, exiting")
             sys.exit(0)
 
-
-class Chdir(object):
-    """ Context manager for changing the current working directory """
-
-    def __init__(self, newPath):
-        self.newPath = os.path.expanduser(newPath)
-
-    def __enter__(self):
-        self.savedPath = os.getcwd()
-        os.chdir(self.newPath)
-
-    def __exit__(self, etype, value, traceback):
-        os.chdir(self.savedPath)

--- a/cekit/test/runner.py
+++ b/cekit/test/runner.py
@@ -3,7 +3,7 @@ import getpass
 import logging
 import subprocess
 
-
+from cekit.tools import Chdir
 from cekit.errors import CekitError
 
 logger = logging.getLogger('cekit')
@@ -58,6 +58,8 @@ class TestRunner(object):
 
         try:
             from behave.__main__ import main as behave_main
-            behave_main(args)
+
+            with Chdir(os.path.join(self.target, 'test')):
+                behave_main(args)
         except:
             raise CekitError("Test execution failed, please consult output above")

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -83,3 +83,16 @@ def get_brew_url(md5):
                      ex.output)
         raise ex
     return url
+
+class Chdir(object):
+    """ Context manager for changing the current working directory """
+
+    def __init__(self, newPath):
+        self.newPath = os.path.expanduser(newPath)
+
+    def __enter__(self):
+        self.savedPath = os.getcwd()
+        os.chdir(self.newPath)
+
+    def __exit__(self, etype, value, traceback):
+        os.chdir(self.savedPath)

--- a/tests/test_addhelp.py
+++ b/tests/test_addhelp.py
@@ -9,7 +9,7 @@ import sys
 import shutil
 import yaml
 import pytest
-from cekit.builders.osbs import Chdir
+from cekit.tools import Chdir
 from cekit.cli import Cekit
 
 image_descriptor = {

--- a/tests/test_expose_services.py
+++ b/tests/test_expose_services.py
@@ -9,7 +9,7 @@ import socket
 import sys
 import yaml
 
-from cekit.builders.osbs import Chdir
+from cekit.tools import Chdir
 from cekit.cli import Cekit
 
 image_descriptor = {

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,7 +5,7 @@ import sys
 import yaml
 import pytest
 
-from cekit.builders.osbs import Chdir
+from cekit.tools import Chdir
 from cekit.errors import CekitError
 from cekit.cli import Cekit
 


### PR DESCRIPTION
Instead of writing it to the current directory, write test output to target/tests/ directory.

Fixes #335.