### PR TITLE
Fix support in plain artifacts handling for OSBS

### DIFF
--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -82,7 +82,11 @@ class OSBSBuilder(Builder):
         self.dist_git.prepare(self._stage, self._user)
         self.dist_git.clean()
 
+        # First get all artifacts that are not plain artifacts
         self.artifacts = [a['name'] for a in descriptor.get('artifacts', []) if not isinstance(a, _PlainResource)]
+        # When plain artifact was handled using lookaside cache, we need to add it too
+        # TODO Rewrite this!
+        self.artifacts += [a['name'] for a in descriptor.get('artifacts', []) if isinstance(a, _PlainResource) and a.get('lookaside')]
 
         if 'packages' in descriptor and 'set_url' in descriptor['packages']:
             self._rhpkg_set_url_repos = [x['url']['repository'] for x in descriptor['packages']['set_url']]

--- a/cekit/generator/docker.py
+++ b/cekit/generator/docker.py
@@ -82,20 +82,6 @@ class DockerGenerator(Generator):
         target_dir = os.path.join(self.target, 'image')
 
         for artifact in self.image['artifacts']:
-            artifact_cache = ArtifactCache()
-            if isinstance(artifact, _PlainResource):
-                if artifact_cache.is_cached(artifact):
-                    pass
-                elif not artifact_cache.is_cached(artifact) and \
-                     config.get('common', 'redhat'):
-                    artifact.url = get_brew_url(artifact['md5'])
-                else:
-                    if 'description' in artifact:
-                        logger.error("Cannot fetch Artifact: '%s', %s" % (artifact['name'],
-                                                                          artifact['description']))
-                    raise CekitError("Cannot fetch Artifact: '%s', please cache it via cekit-cache."
-                                     % artifact['name'])
-
             artifact.copy(target_dir)
 
         logger.debug("Artifacts handled")

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -57,11 +57,16 @@ def decision(question):
 
 def get_brew_url(md5):
     try:
-        logger.info("Getting brew details for an artifact with '%s' md5 sum" % md5)
+        logger.debug("Getting brew details for an artifact with '%s' md5 sum" % md5)
         list_archives_cmd = ['brew', 'call', '--json-output', 'listArchives',
                              'checksum=%s' % md5, 'type=maven']
         logger.debug("Executing '%s'." % " ".join(list_archives_cmd))
-        archive = yaml.safe_load(subprocess.check_output(list_archives_cmd))[0]
+        archive_yaml = yaml.safe_load(subprocess.check_output(list_archives_cmd))
+
+        if not archive_yaml:
+            raise CekitError("Artifact with md5 checksum %s could not be found in Brew" % md5)
+
+        archive = archive_yaml[0]
         build_id = archive['build_id']
         filename = archive['filename']
         group_id = archive['group_id']

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -431,7 +431,7 @@ def test_run_path_artifact_brew(tmpdir, mocker, caplog):
 
     run_cekit_exception(image_dir)
 
-    assert "Cannot fetch Artifact: 'aaa', please cache it via cekit-cache." in caplog.text
+    assert "Cekit is not able to fetch resource 'aaa' automatically. Please use cekit-cache command to add this artifact manually." in caplog.text
 
 
 def test_run_path_artifact_target(tmpdir, mocker):


### PR DESCRIPTION
If the artifact is a plain artifact and it does not exists in Brew, OSBS builds is failing.

It was fixed by falling back into the regular procedure (check local, remote cache).
If this fails, the build fails. If it doesn't, OSBS will use a mix of artifacts:
fetched using fetch-artifacts-url.yaml and from lookaside cache. Approriate
warnings are added.