### PR TITLE
Paths to content_sets and container files should be relative to descriptor

### DIFF
--- a/cekit/descriptor/image.py
+++ b/cekit/descriptor/image.py
@@ -59,9 +59,9 @@ class Image(Descriptor):
         self._descriptor['artifacts'] = [Resource(a, directory=self._artifact_dir)
                                          for a in self._descriptor.get('artifacts', [])]
         self._descriptor['modules'] = Modules(self._descriptor.get('modules', {}), self.path)
-        self._descriptor['packages'] = Packages(self._descriptor.get('packages', {}))
+        self._descriptor['packages'] = Packages(self._descriptor.get('packages', {}), self.path)
         if 'osbs' in self._descriptor:
-            self._descriptor['osbs'] = Osbs(self._descriptor['osbs'])
+            self._descriptor['osbs'] = Osbs(self._descriptor['osbs'], self.path)
         self._descriptor['volumes'] = [Volume(x) for x in self._descriptor.get('volumes', [])]
 
         # make sure image declarations override any module definitions
@@ -151,11 +151,11 @@ class Image(Descriptor):
 
     @property
     def packages(self):
-        return self.get('packages', Packages({}))
+        return self.get('packages', Packages({}, self.path))
 
     @property
     def osbs(self):
-        return self.get('osbs', Osbs({}))
+        return self.get('osbs', Osbs({}, self.path))
 
     @osbs.setter
     def osbs(self, value):

--- a/cekit/descriptor/osbs.py
+++ b/cekit/descriptor/osbs.py
@@ -26,12 +26,13 @@ class Osbs(Descriptor):
     Args:
       descriptor - yaml containing Osbs object
     """
-    def __init__(self, descriptor):
+    def __init__(self, descriptor, descriptor_path):
         self.schemas = osbs_schema
+        self.descriptor_path = descriptor_path
         super(Osbs, self).__init__(descriptor)
 
         if 'configuration' in self:
-            self['configuration'] = Configuration(self['configuration'])
+            self['configuration'] = Configuration(self['configuration'], self.descriptor_path)
 
     @property
     def name(self):
@@ -59,8 +60,9 @@ class Configuration(Descriptor):
     Args:
       descriptor - yaml contianing OSBS configuration"""
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor, descriptor_path):
         self.schemas = configuration_schema
+        self.descriptor_path = descriptor_path
         super(Configuration, self).__init__(descriptor)
         self.skip_merging = ['container', 'container_file']
 
@@ -69,8 +71,9 @@ class Configuration(Descriptor):
             raise CekitError('You cannot specify container and container_file together!')
 
         if 'container_file' in self:
-            if not os.path.exists(self['container_file']):
-                raise CekitError("'%s' file not found!" % self['container_file'])
-            with open(self['container_file'], 'r') as file_:
+            container_file = os.path.join(self.descriptor_path, self['container_file'])
+            if not os.path.exists(container_file):
+                raise CekitError("'%s' file not found!" % container_file)
+            with open(container_file, 'r') as file_:
                 self['container'] = yaml.safe_load(file_)
             del self['container_file']

--- a/cekit/descriptor/packages.py
+++ b/cekit/descriptor/packages.py
@@ -45,16 +45,22 @@ class Packages(Descriptor):
     Args:
       descriptor - yaml containing Packages section
     """
-    def __init__(self, descriptor):
+    def __init__(self, descriptor, descriptor_path):
         self.schemas = packages_schema
+        self.descriptor_path = descriptor_path
         super(Packages, self).__init__(descriptor)
         if ('content_sets_file' in descriptor and 'content_sets' in descriptor):
             raise CekitError("You cannot specify content_sets and content_sets_file together!")
 
         if 'content_sets_file' in descriptor:
-            with open(descriptor['content_sets_file'], 'r') as file_:
+            content_sets_file = os.path.join(self.descriptor_path, descriptor['content_sets_file'])
+
+            if not os.path.exists(content_sets_file):
+                raise CekitError("'%s' file not found!" % content_sets_file)
+
+            with open(content_sets_file, 'r') as file_:
                 descriptor['content_sets'] = yaml.safe_load(file_)
-                del descriptor['content_sets_file']
+            del descriptor['content_sets_file']
 
         self._prepare()
 

--- a/tests/test_unit_descriptor.py
+++ b/tests/test_unit_descriptor.py
@@ -61,7 +61,7 @@ def test_osbs():
     repository:
       name: foo
       branch: bar
-"""))
+"""), "a/path/image.yaml")
 
     assert osbs['repository']['name'] == 'foo'
     assert osbs['repository']['branch'] == 'bar'
@@ -74,7 +74,7 @@ def test_packages(mocker):
           - repo-foo
           - repo-bar
       install:
-          - pkg-foo"""))
+          - pkg-foo"""), "a/path/image.yaml")
 
     assert Repository('repo-foo') in pkg['repositories']
     assert Repository('repo-bar') in pkg['repositories']


### PR DESCRIPTION
When you specify container_file or content_sets_files in your image
descriptor, these locations will be relative to the directory
where image descriptor is stored.