### PR TITLE
Debug-log arguments collected for "behave"

### DIFF
--- a/cekit/test/runner.py
+++ b/cekit/test/runner.py
@@ -60,6 +60,7 @@ class TestRunner(object):
             from behave.__main__ import main as behave_main
 
             with Chdir(os.path.join(self.target, 'test')):
+                logger.debug("behave args: {}".format(args))
                 if behave_main(args) != 0:
                     raise CekitError("Test execution failed, please consult output above")
         except CekitError:


### PR DESCRIPTION
When diagnosing test problems, it can be helpful to run "behave"
by hand. It's useful to know exactly how cekit was invoking "behave",
to figure out what tags are selected or de-selected, etc.

Log (to debug logger) the collected arguments prior to starting
"behave".

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>