### PR TITLE
Move support for defining package managers to image definition

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ pytest-mock = "*"
 docker = "*"
 docker-squash = "*"
 click = "*"
-pylint = "<2.0.0"
+pylint = "*"
 autopep8 = "*"
 
 [packages]

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ pytest-mock = "*"
 docker = "*"
 docker-squash = "*"
 click = "*"
+pylint = "<2.0.0"
+autopep8 = "*"
 
 [packages]
 pykwalify = ">=1.6.0"

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -26,10 +26,8 @@ CONFIG = Config()
 @click.option('--config', metavar="PATH", help="Path to configuration file.", default="~/.cekit/config", show_default=True)
 @click.option('--redhat', help="Set default options for Red Hat internal infrastructure.", is_flag=True)
 @click.option('--target', metavar="PATH", help="Path to directory where files should be generated", default="target", show_default=True)
-# TODO: Remove this option
-@click.option('--package-manager', help="Package manager to use.", type=click.Choice(['yum', 'microdnf']), default="yum", show_default=True)
 @click.version_option(message="%(version)s", version=version)
-def cli(descriptor, verbose, work_dir, config, redhat, target, package_manager):  # pylint: disable=unused-argument,too-many-arguments
+def cli(descriptor, verbose, work_dir, config, redhat, target):  # pylint: disable=unused-argument,too-many-arguments
     """
     ABOUT
 
@@ -321,8 +319,6 @@ class Cekit(object):  # pylint: disable=useless-object-inheritance
                              'work_dir': self.params.work_dir,
                              # TODO: https://github.com/cekit/cekit/issues/377
                              'addhelp': self.params.addhelp,
-                             # TODO: Remove it from here: https://github.com/cekit/cekit/issues/400
-                             'package_manager': self.params.package_manager
                          })
 
     def cleanup(self):

--- a/cekit/config.py
+++ b/cekit/config.py
@@ -23,9 +23,6 @@ class Config(object):
             cls.cfg['common']['redhat'] = cmdline_args.get('redhat')
         if cmdline_args.get('work_dir'):
             cls.cfg['common']['work_dir'] = cmdline_args.get('work_dir')
-        # TODO: Remove it from here: https://github.com/cekit/cekit/issues/400
-        if cmdline_args.get('package_manager'):
-            cls.cfg['common']['package_manager'] = cmdline_args.get('package_manager')
         # TODO: https://github.com/cekit/cekit/issues/377
         if isinstance(cmdline_args.get('addhelp'), bool):
             cls.cfg['doc']['addhelp'] = cmdline_args.get('addhelp')
@@ -44,8 +41,6 @@ class Config(object):
         cls.cfg['common']['work_dir'] = cls.cfg.get('common').get('work_dir', '~/.cekit')
         cls.cfg['common']['redhat'] = yaml.safe_load(
             cls.cfg.get('common', {}).get('redhat', 'False'))
-        cls.cfg['common']['package_manager'] = yaml.safe_load(
-            cls.cfg.get('common', {}).get('package_manager', 'yum'))
 
         cls.cfg['doc'] = cls.cfg.get('doc', {})
         cls.cfg['doc']['addhelp'] = yaml.safe_load(

--- a/cekit/descriptor/packages.py
+++ b/cekit/descriptor/packages.py
@@ -19,7 +19,8 @@ map:
       - {type: any}
   install:
     seq:
-      - {type: any}""")]
+      - {type: any}
+  manager: {type: str, enum: ['yum', 'dnf', 'microdnf'], default: 'yum'}""")]
 
 
 repository_schema = yaml.safe_load("""

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -230,8 +230,6 @@ class Generator(object):
         """Renders Dockerfile to $target/image/Dockerfile"""
         LOGGER.info("Rendering Dockerfile...")
 
-        self.image['pkg_manager'] = CONFIG.get('common', 'package_manager')
-
         template_file = os.path.join(os.path.dirname(__file__),
                                      '..',
                                      'templates',

--- a/cekit/template_helper.py
+++ b/cekit/template_helper.py
@@ -3,6 +3,8 @@ import os
 
 class TemplateHelper(object):
 
+    SUPPORTED_PACKAGE_MANAGERS = ['yum', 'dnf', 'microdnf']
+
     def __init__(self, module_registry):
         self._module_registry = module_registry
 

--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -1,5 +1,5 @@
 {% macro repo_create(pkg_manager, repositories) -%}
-    {% if pkg_manager in ['microdnf', 'yum'] %}
+    {% if pkg_manager in helper.SUPPORTED_PACKAGE_MANAGERS %}
         {% for repo in repositories %}
 repos/{{ repo.filename }} \
         {% endfor %}
@@ -7,28 +7,28 @@ repos/{{ repo.filename }} \
     {% endif %}
 {%- endmacro %}
 {% macro repo_remove(pkg_manager, repositories) -%}
-    {% if pkg_manager in ['microdnf', 'yum'] %}
+    {% if pkg_manager in helper.SUPPORTED_PACKAGE_MANAGERS %}
 rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %}
     {% endif %}
 {%- endmacro %}
 {% macro repo_install(pkg_manager, rpm) -%}
-    {% if pkg_manager in ['microdnf', 'yum'] %}
+    {% if pkg_manager in helper.SUPPORTED_PACKAGE_MANAGERS %}
 {{ pkg_manager }} --setopt=tsflags=nodocs install -y {{ rpm }}
     {% endif %}
 {%- endmacro %}
 {% macro pkg_install(pkg_manager, packages) -%}
-    {% if pkg_manager in ['microdnf', 'yum'] %}
+    {% if pkg_manager in helper.SUPPORTED_PACKAGE_MANAGERS %}
 {{ pkg_manager }} --setopt=tsflags=nodocs install -y {%- for package in packages %} {{ package }}{% endfor %} \
     && rpm -q{% for package in packages %} {{ package }}{% endfor %}
     {% endif %}
 {%- endmacro %}
 {% macro repo_make_cache(pkg_manager) -%}
-    {% if pkg_manager in ['microdnf', 'yum'] %}
+    {% if pkg_manager in helper.SUPPORTED_PACKAGE_MANAGERS %}
 {{ pkg_manager }} makecache
     {% endif %}
 {%- endmacro %}
 {% macro repo_clear_cache(pkg_manager) -%}
-    {% if pkg_manager in ['microdnf', 'yum'] %}
+    {% if pkg_manager in helper.SUPPORTED_PACKAGE_MANAGERS %}
 {{ pkg_manager }} clean all && [ ! -d /var/cache/yum ] || rm -rf /var/cache/yum
     {% endif %}
 {%- endmacro %}
@@ -38,7 +38,7 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
 
 # Install required RPMs and ensure that the packages were installed
 USER root
-RUN {{ pkg_install(pkg_manager, module.packages.install) }}
+RUN {{ pkg_install(packages.manager, module.packages.install) }}
 {% endif %}
 {% if helper.envs(module.envs)|length > 0 %}
 
@@ -106,19 +106,19 @@ USER root
 {% if packages.repositories_injected %}
 
 # Add custom repo files
-COPY {{ repo_create(pkg_manager, packages.repositories_injected) }}
+COPY {{ repo_create(packages.manager, packages.repositories_injected) }}
 {% endif %}
 {% if packages.repositories %}
 {% for repo in packages.repositories %}
 {% if repo.present and repo.rpm %}
 
-RUN {{ repo_install(pkg_manager, repo.rpm) }}
+RUN {{ repo_install(packages.manager, repo.rpm) }}
 {% endif %}
 {% endfor %}
 {% endif %}
 
 {% if helper.packages_to_install(image) %}
-RUN {{ repo_make_cache(pkg_manager) }}
+RUN {{ repo_make_cache(packages.manager) }}
 {% endif %}
 
 {% if image.modules.install|length > 0 %}
@@ -146,12 +146,12 @@ RUN [ ! -d /tmp/artifacts ] || rm -rf /tmp/artifacts
 
 {% if helper.packages_to_install(image) %}
 # Clear package manager metadata
-RUN {{ repo_clear_cache(pkg_manager) }}
+RUN {{ repo_clear_cache(packages.manager) }}
 {% endif %}
 
 {% if packages.repositories_injected %}
 # Remove custom repo files
-RUN {{ repo_remove(pkg_manager, packages.repositories_injected) }}
+RUN {{ repo_remove(packages.manager, packages.repositories_injected) }}
 {% endif %}
 
 # Run user

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -3,7 +3,7 @@
 Contributing to the project
 ===========================
 
-We strongly advise to use `Virtualenv <https://virtualenv.pypa.io/en/stable/>`_ to develop CEKit. Please consult your package manager for the correct package name. Currently within Fedora 29 all the required packages are available as RPMs. A sample set of Ansible scripts that provide all pre-requistites for development are available `here <https://github.com/cekit/cekit/tree/develop/support/ansible>`_.
+We strongly advise to use `Virtualenv <https://virtualenv.pypa.io/en/stable/>`__ to develop CEKit. Please consult your package manager for the correct package name. Currently within Fedora 29 all the required packages are available as RPMs. A sample set of Ansible scripts that provide all pre-requistites for development are available `here <https://github.com/cekit/cekit/tree/develop/support/ansible>`_.
 
 - If you are running inside the Red Hat infrastructure then ``rhpkg`` must be installed as well.
 
@@ -21,7 +21,7 @@ To create custom Python virtual environment please run following commands on you
     # Now you are able to run CEKit
     cekit --help
 
-It is possible to ask virtualenv to inherit pre-installed system packages thereby reducing the virtualenv to a delta between what is installed and what is required. This is achived by using the flag ``--system-site-packages`` (See `here <https://virtualenv.pypa.io/en/latest/userguide/#the-system-site-packages-option>`_ for further information).
+It is possible to ask virtualenv to inherit pre-installed system packages thereby reducing the virtualenv to a delta between what is installed and what is required. This is achived by using the flag ``--system-site-packages`` (See `here <https://virtualenv.pypa.io/en/latest/userguide/#the-system-site-packages-option>`__ for further information).
 
 .. note::
 
@@ -89,7 +89,7 @@ Guidelines
 ~~~~~~~~~~
 
 Below you can find a list of conventions used to write CEKit documentation. Reference information on reStructuredText
-may be found `here <http://docutils.sourceforge.net/rst.html>`_.
+may be found `here <http://docutils.sourceforge.net/rst.html>`__.
 
 Headers
 ^^^^^^^

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -4,9 +4,9 @@ Building images
 CEKit supports following builder engines:
 
 * Docker -- builds the container image using the Docker daemon, this is the default option
-* OSBS -- builds the container image using `OSBS service <https://osbs.readthedocs.io>`_
-* Buildah -- builds the container image using `Buildah <https://buildah.io/>`_
-* Podman -- builds the container image using `Podman <https://podman.io/>`_
+* OSBS -- builds the container image using `OSBS service <https://osbs.readthedocs.io>`__
+* Buildah -- builds the container image using `Buildah <https://buildah.io/>`__
+* Podman -- builds the container image using `Podman <https://podman.io/>`__
 
 Executing builds
 -----------------
@@ -17,7 +17,7 @@ You can execute container image build by running:
 
 	  $ cekit build
 
-**Global options
+Global options
 
 **Options affecting builder:**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,8 @@ def setup(app):
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autosectionlabel', 'sphinx.ext.todo']
+# http://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html#confval-autosectionlabel_prefix_document
+autosectionlabel_prefix_document = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/descriptor/artifacts.rst
+++ b/docs/descriptor/artifacts.rst
@@ -21,7 +21,7 @@ the base name of the file/URL.
    For artifacts that are not publicly available CEKit provides a way to
    add a description detailing a location from which the artifact can be obtained.
 
-   .. code:: yaml
+   .. code-block:: yaml
 
       artifacts:
         - path: jboss-eap-6.4.0.zip
@@ -34,8 +34,8 @@ the base name of the file/URL.
 
 
 
-Plain
-^^^^^
+Plain artifacts
+^^^^^^^^^^^^^^^^^^^^
 
 This is the easiest way of defining an artifact. You are just specifying its name and **md5** checksum.
 This approach relies on :ref:`artifacts_caching` to provide the artifact in cache. This section should be used to show that a particular artifact is needed for the image but its not publicly available.
@@ -53,13 +53,13 @@ This approach relies on :ref:`artifacts_caching` to provide the artifact in cach
    Hat switch.
 
           
-URL
-^^^
+URL artifacts
+^^^^^^^^^^^^^^^^^^
 
 This way of defining repository ask CEKit to download and artifact from a specified URL.
 
 
-.. code:: yaml
+.. code-block:: yaml
 
     artifacts:
         - name: jolokia-1.3.6-bin.tar.gz
@@ -69,13 +69,13 @@ This way of defining repository ask CEKit to download and artifact from a specif
 
 
 
-Path
-^^^^
+Path artifacts
+^^^^^^^^^^^^^^^^^^^
 
 This way of defining artifact is mostly used in development overrides and enables you to inject
 an artifact from a local filesystem.
 
-.. code:: yaml
+.. code-block:: yaml
 
     artifacts:
         - name: jolokia-1.3.6-bin.tar.gz

--- a/docs/descriptor/module.rst
+++ b/docs/descriptor/module.rst
@@ -38,4 +38,4 @@ Module name.
 .. include:: modules.rst
 .. include:: workdir.rst
 .. include:: run.rst
-.. include:: execs.rst	     
+.. include:: execs.rst

--- a/docs/descriptor/osbs.rst
+++ b/docs/descriptor/osbs.rst
@@ -31,7 +31,7 @@ This key is holding OSBS ``container.yaml`` file ( `OSBS docs <https://osbs.read
 
 
 Embedded
-""""""""
+*********
 In this case whole ``container.yaml`` file is embedded in an image descriptor.
 
 .. code:: yaml
@@ -43,7 +43,7 @@ In this case whole ``container.yaml`` file is embedded in an image descriptor.
                   pulp_repos: true
 
 Linked
-""""""
+*********
 
 In this case ``container.yaml`` file is read from a file located next to the image descriptor.
 

--- a/docs/descriptor/packages.rst
+++ b/docs/descriptor/packages.rst
@@ -2,9 +2,10 @@ Packages
 --------
 
 To install additional RPM packages you can use the ``packages``
-section where you specify package names and repositories to be used.
+section where you specify package names and repositories to be used, as well
+as the package manager that is used to manage packages in this image.
 
-.. code:: yaml
+.. code-block:: yaml
 
     packages:
         install:
@@ -16,12 +17,32 @@ section where you specify package names and repositories to be used.
 
 Packages are defined in the ``install`` subsection.
 
-.. _repo:
+Package manager
+^^^^^^^^^^^^^^^^^^
 
-Repositories
-------------
+It is possible to define package manager used in the image
+used to install packages as part of the build process.
+
+Currently available options are ``yum``, ``dnf``, and ``microdnf``.
+
+.. note::
+    If you do not specify this key the default value is ``yum``.
+    
+    It will work fine on Fedora and RHEL images because OS maintains
+    a symlink to the proper package manager. 
+
+.. code-block:: yaml
+
+    packages:
+        manager: dnf
+        install:
+            - git
+
+Package repositories
+^^^^^^^^^^^^^^^^^^^^^
+
 CEKit uses all repositories configured inside the image. You can also specify additional
-repositories using repositories subsection. CEKit currently supports following multiple ways of defining
+repositories using repositories subsection. CEKit currently supports following ways of defining
 additional repositories:
 
 * Plain
@@ -30,16 +51,15 @@ additional repositories:
 * ContentSets
 
 .. note::
-   See :ref:`Repository mangement<repository_management>` to learn about best practices for repository
+   See :ref:`Repository management<repository_management>` to learn about best practices for repository
    definitions.
 
-.. _repo_plain:
+Plain repository
+******************
 
-Plain
-^^^^^
 This is the default option. With this approach you specify repository id and CEKit will not perform any action and expect the repository definition exists inside the image. This is useful as a hint which repository must be present for particular image to be buildable. The definition can be overridden by your preferred way of injecting repositories inside the image.
 
-.. code:: yaml
+.. code-block:: yaml
 
     packages:
         repositories:
@@ -47,30 +67,29 @@ This is the default option. With this approach you specify repository id and CEK
               id: rhel7-extras-rpm
               description: "Repository containing extras RHEL7 extras packages"
 
-.. _repo_rpm:
+RPM repository
+***************
 
-RPM
-^^^^
 This ways is using repository configuration files and related keys packaged as an RPM.
 
 **Example**: To enable `CentOS SCL <https://wiki.centos.org/AdditionalResources/Repositories/SCL>`_ inside the
 image you should define repository in a following way:
 
-.. code:: yaml
+.. code-block:: yaml
 
     packages:
         repositories:
             - name: scl
               rpm: centos-release-scl
 
-.. _repo_url:
+URL repository
+****************
 
-URL
-^^^^
+
 This approach enables you to download a yum repository file and corresponding GPG key. To do it, define
 repositories section in a way of:
 
-.. code:: yaml
+.. code-block:: yaml
 
     packages:
         repositories:
@@ -80,11 +99,10 @@ repositories section in a way of:
                 gpg: https://web.exmaple/foo.gpg
 
 
-.. _repo_contentsets:
-
-
 Content sets
-^^^^^^^^^^^^
+**************************
+
+
 Content sets are tightly integrated to OSBS style of defining repositories in ``content_sets.yml`` file.
 If this kind of repository is present in the image descriptor it overrides all other repositories types.
 For local Docker based build these repositories are ignored similarly to Plain repository types and
@@ -97,11 +115,12 @@ content sets.
 
 There are two possibilities how to define Content sets type of repository:
 
-Embedded
-""""""""
+Embedded content sets
+++++++++++++++++++++++++
+
 In this approach content sets are embedded inside image descriptor under the ``content_sets`` key.
 
-.. code:: yaml
+.. code-block:: yaml
 
     packages:
         content_sets:
@@ -110,14 +129,15 @@ In this approach content sets are embedded inside image descriptor under the ``c
             - server-extras-rpms
 
 
-Linked
-""""""
+Linked content sets
+++++++++++++++++++++++++
+
 In this approach Contet sets file is linked from a separate yaml file next to image descriptor via
 ``content_sets_file`` key.
 
 Image descriptor:
 
-.. code:: yaml
+.. code-block:: yaml
 
     packages:
         content_sets_file: content_sets.yml
@@ -125,7 +145,7 @@ Image descriptor:
 
 ``content_sets.yml`` located next to image descriptor:
 
-.. code:: yaml
+.. code-block:: yaml
 
      x86_64:
        - server-rpms

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -12,7 +12,7 @@ which contains everything needed to install CEKit.
 
 .. warning::
 
-   Make sure you read the `dependencies`_ section of this documentation which contains important
+   Make sure you read the :doc:`dependencies chapter</installation/dependencies>` of this documentation which contains important
    information about how CEKit dependencies are handled!
 
 Fedora

--- a/docs/repository_management.rst
+++ b/docs/repository_management.rst
@@ -20,8 +20,8 @@ To achieve such behavior in Red Hat Middleware Container Images we created follo
 Defining repositories in container images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You should use :ref:`Plain<repo_plain>` repository definition for every repository as this will work easily on Red Hat subscribed host and will assume everyone can rebuild are RHEL based images.
-
+You should use :doc:`Plain repository definition</descriptor/image>` for every repository as this will work
+easily on Red Hat subscribed host and will assume everyone can rebuild are RHEL based images.
 
 *Example:* Define Software Collections repository
 
@@ -32,7 +32,13 @@ You should use :ref:`Plain<repo_plain>` repository definition for every reposito
             - name: SCL
               id: rhel-server-rhscl-7-rpms
 
-If you have repository defined this way, CEKit will not try to inject it and will expect the repository to be already available inside your container image. If it's not provided by the image (for example repository definition already available in ``/etc/yum.repos.d/`` directory) or the host (for example on via `subscribed RHEL host <https://access.redhat.com/solutions/1443553>`_) you need to override this repository. To override a repository definition you need to specify a repository with same ``name``. By overriding Plain repository type, you are actually saying that you have an external mechanism to inject the repository inside the image. This can be any supported :ref:`repository type<repo>`.
+If you have repository defined this way, CEKit will not try to inject it and will expect the repository
+to be already available inside your container image. If it's not provided by the image (for example
+repository definition already available in ``/etc/yum.repos.d/`` directory) or the host (for example on
+via `subscribed RHEL host <https://access.redhat.com/solutions/1443553>`_) you need to override this
+repository. To override a repository definition you need to specify a repository with same ``name``.
+By overriding Plain repository type, you are actually saying that you have an external mechanism to
+inject the repository inside the image. This can be any supported :doc:`repository type</descriptor/image>`.
 
 .. note::
    You can view Plain repository type as an abstract classes and ODCS, RPM and URL repositories as an actual implementation.

--- a/docs/testing/behave.rst
+++ b/docs/testing/behave.rst
@@ -58,7 +58,7 @@ rather than the image itself. In our experience we see that this is the most com
 
 .. note::
     CEKit makes it possible to colocate tests with image source as well as module source. Please
-    take a look at the :ref:`Test file locations` section for more information where these should be placed.
+    take a look at the :ref:`testing/behave:Test file locations` section for more information where these should be placed.
 
 Placing feature files together with modules makes it easy to share the feature as well as tests.
 Such tests could be run by multiple different images which use this particular module.
@@ -77,7 +77,7 @@ We suggest to read this, if it does not answer all your questions, `let us know 
 
 .. note::
     For information how you can write your own steps, please take a look at the
-    :ref:`Writing custom steps` paragraph.
+    :ref:`testing/behave:Writing custom steps` paragraph.
 
 Default steps
 **************
@@ -160,7 +160,7 @@ Skipping tests
 ***********************
 
 .. hint::
-    See :ref:`Special tags` paragraph.
+    See :ref:`testing/behave:Special tags` paragraph.
 
 If there is a particular test which needs to be temporally disabled, you can use ``@ignore``
 tag to disable it.
@@ -277,10 +277,10 @@ The ``tests`` directory is structured as follows:
         tests/steps/*.py
 
 The ``tests/features`` directory is the place where you can drop your `behave
-features. <https://behave.readthedocs.io/en/latest/tutorial.html#features>`_
+features. <https://behave.readthedocs.io/en/latest/tutorial.html#features>`__
 
 The ``tests/steps`` directory is optional and contains custom `steps
-<https://behave.readthedocs.io/en/latest/tutorial.html#python-step-implementations>`_
+<https://behave.readthedocs.io/en/latest/tutorial.html#python-step-implementations>`__
 for the specific image/module.
 
 Writing features

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -23,7 +23,7 @@ def get_class_by_name(clazz):
         ['--redhat', 'build', 'docker'],
         'cekit.builders.docker_builder.DockerBuilder',
         {
-            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': True, 'target': 'target', 'package_manager': 'yum', 'addhelp': None
+            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': True, 'target': 'target', 'addhelp': None
         },
         {
             'dry_run': False, 'overrides': (), 'addhelp': None, 'pull': False, 'no_squash': False, 'tags': ()
@@ -34,7 +34,7 @@ def get_class_by_name(clazz):
         ['--target', 'custom-target', 'build', 'docker'],
         'cekit.builders.docker_builder.DockerBuilder',
         {
-            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': False, 'target': 'custom-target', 'package_manager': 'yum', 'addhelp': None
+            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': False, 'target': 'custom-target', 'addhelp': None
         },
         {
             'dry_run': False, 'overrides': (), 'addhelp': None, 'pull': False, 'no_squash': False, 'tags': ()
@@ -45,7 +45,7 @@ def get_class_by_name(clazz):
         ['--work-dir', 'custom-workdir', 'build', 'docker'],
         'cekit.builders.docker_builder.DockerBuilder',
         {
-            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': 'custom-workdir', 'config': '~/.cekit/config', 'redhat': False, 'target': 'target', 'package_manager': 'yum', 'addhelp': None
+            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': 'custom-workdir', 'config': '~/.cekit/config', 'redhat': False, 'target': 'target', 'addhelp': None
         },
         {
             'dry_run': False, 'overrides': (), 'addhelp': None, 'pull': False, 'no_squash': False, 'tags': ()
@@ -56,7 +56,7 @@ def get_class_by_name(clazz):
         ['--config', 'custom-config', 'build', 'docker'],
         'cekit.builders.docker_builder.DockerBuilder',
         {
-            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': 'custom-config', 'redhat': False, 'target': 'target', 'package_manager': 'yum', 'addhelp': None
+            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': 'custom-config', 'redhat': False, 'target': 'target', 'addhelp': None
         },
         {
             'dry_run': False, 'overrides': (), 'addhelp': None, 'pull': False, 'no_squash': False, 'tags': ()
@@ -120,7 +120,7 @@ def get_class_by_name(clazz):
         ['test', '--image', 'image:1.0', 'behave'],
         'cekit.test.behave.BehaveTester',
         {
-            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': False, 'target': 'target', 'package_manager': 'yum'
+            'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': False, 'target': 'target'
         },
         {
             'image': 'image:1.0', 'steps_url': 'https://github.com/cekit/behave-test-steps.git', 'wip': False, 'names': ()
@@ -162,7 +162,7 @@ def test_args_command(mocker, args, clazz, common_params, params):
     if not common_params:
         common_params = {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit',
-            'config': '~/.cekit/config', 'redhat': False, 'target': 'target', 'package_manager': 'yum', 'addhelp': None
+            'config': '~/.cekit/config', 'redhat': False, 'target': 'target', 'addhelp': None
         }
 
     cekit_class = mocker.patch('cekit.cli.Cekit')
@@ -176,7 +176,7 @@ def test_args_command(mocker, args, clazz, common_params, params):
     cekit_object.run.assert_called_once_with(cls, params)
 
 
-def test_args_not_valid_command(mocker):
+def test_args_not_valid_command():
     result = CliRunner().invoke(cli, ['explode'], catch_exceptions=False)
 
     assert isinstance(result.exception, SystemExit)


### PR DESCRIPTION
This removes support for defining package manager used to install packages
from the command line (and configuration file) to the image descriptor
itself.

Adds support for dnf.

Fixes #400