### PR TITLE
Make Behave tester work again

### DIFF
--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -260,7 +260,7 @@ def run_command(ctx, clazz):
 
 def run_test(ctx, tester):
     if tester == 'behave':
-        from cekit.test.behave import BehaveTester as tester_impl
+        from cekit.test.behave_tester import BehaveTester as tester_impl
         LOGGER.info("Using Behave tester to test the image")
     else:
         raise CekitError("Tester engine {} is not supported".format(tester))
@@ -289,7 +289,7 @@ def run_build(ctx, builder):
     run_command(ctx, builder_impl)
 
 
-class Cekit(object):  # pylint: disable=useless-object-inheritance
+class Cekit(object):
     """ Main application """
 
     def __init__(self, params):

--- a/cekit/test/collector.py
+++ b/cekit/test/collector.py
@@ -7,7 +7,7 @@ import sys
 logger = logging.getLogger('cekit')
 
 
-class TestCollector(object):
+class BehaveTestCollector(object):
     def __init__(self, descriptor_dir, target_dir):
         self.collected = False
         self.descriptor_dir = os.path.abspath(descriptor_dir)

--- a/tests/test_integ_test_behave.py
+++ b/tests/test_integ_test_behave.py
@@ -1,0 +1,72 @@
+# -*- encoding: utf-8 -*-
+
+import os
+import shutil
+import tempfile
+
+import pytest
+import yaml
+
+from click.testing import CliRunner
+
+from cekit.cli import cli
+from cekit.tools import Chdir
+
+
+image_descriptor = {
+    'schema_version': 1,
+    'from': 'alpine:3.9',
+    'name': 'test/image',
+    'version': '1.0',
+    'labels': [{'name': 'foo', 'value': 'bar'}, {'name': 'labela', 'value': 'a'}],
+    'envs': [{'name': 'baz', 'value': 'qux'}, {'name': 'enva', 'value': 'a'}],
+    'run': {'cmd': ['tail', '-f', '/dev/null']},
+}
+
+
+@pytest.fixture(scope="module", name="test_image_dir")
+def build_test_image_dir():
+    image_dir = tempfile.mkdtemp(prefix="tmp-cekit-test")
+
+    with open(os.path.join(image_dir, 'image.yaml'), 'w') as fd:
+        yaml.dump(image_descriptor, fd, default_flow_style=False)
+
+    with Chdir(image_dir):
+        result = CliRunner().invoke(cli, ["-v", "build", "docker"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+
+    return image_dir
+
+
+@pytest.fixture(autouse=True)
+def clean_target_directory(test_image_dir):
+    shutil.rmtree(os.path.join(test_image_dir, 'target'), ignore_errors=True)
+
+
+def test_execute_simple_behave_test(test_image_dir):
+    feature = """@test
+Feature: Basic tests
+
+  Scenario: Check that the labels are correctly set
+    Given image is built
+    Then the image should contain label foo with value bar
+     And the image should contain label labela with value a
+    """
+
+    features_dir = os.path.join(test_image_dir, 'tests', 'features')
+
+    os.makedirs(features_dir)
+
+    with open(os.path.join(features_dir, 'basic.feature'), 'w') as fd:
+        fd.write(feature)
+
+    with Chdir(test_image_dir):
+        result = CliRunner().invoke(cli, ["-v", "test", "behave"], catch_exceptions=False)
+
+    print(result.output)
+
+    assert result.exit_code == 0
+    assert "1 feature passed, 0 failed, 0 skipped" in result.output
+    assert "1 scenario passed, 0 failed, 0 skipped" in result.output
+    assert "3 steps passed, 0 failed, 0 skipped, 0 undefined" in result.output

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -118,7 +118,7 @@ def get_class_by_name(clazz):
     ),
     (
         ['test', '--image', 'image:1.0', 'behave'],
-        'cekit.test.behave.BehaveTester',
+        'cekit.test.behave_tester.BehaveTester',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': False, 'target': 'target', 'package_manager': 'yum'
         },

--- a/tests/test_unit_collector.py
+++ b/tests/test_unit_collector.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import pytest
 
-from cekit.test.collector import TestCollector
+from cekit.test.collector import BehaveTestCollector
 
 desc_dir = "/tmp/desc"
 target_dir = "/tmp/target_dir"
@@ -19,8 +19,8 @@ def prepare_dirs():
 
 
 def test_collect_test_from_image_repo(prepare_dirs, mocker):
-    mocker.patch.object(TestCollector, '_fetch_steps')
-    collector = TestCollector(desc_dir, target_dir)
+    mocker.patch.object(BehaveTestCollector, '_fetch_steps')
+    collector = BehaveTestCollector(desc_dir, target_dir)
 
     features_file = os.path.join(desc_dir,
                                  'tests',
@@ -41,8 +41,8 @@ def test_collect_test_from_image_repo(prepare_dirs, mocker):
 
 
 def test_collect_test_from_repository_root(prepare_dirs, mocker):
-    mocker.patch.object(TestCollector, '_fetch_steps')
-    collector = TestCollector(desc_dir, target_dir)
+    mocker.patch.object(BehaveTestCollector, '_fetch_steps')
+    collector = BehaveTestCollector(desc_dir, target_dir)
 
     features_file = os.path.join(target_dir,
                                  'repo',
@@ -65,8 +65,8 @@ def test_collect_test_from_repository_root(prepare_dirs, mocker):
 
 
 def test_collect_test_from_module(prepare_dirs, mocker):
-    mocker.patch.object(TestCollector, '_fetch_steps')
-    collector = TestCollector(desc_dir, target_dir)
+    mocker.patch.object(BehaveTestCollector, '_fetch_steps')
+    collector = BehaveTestCollector(desc_dir, target_dir)
 
     features_file = os.path.join(target_dir,
                                  'image',
@@ -90,9 +90,9 @@ def test_collect_test_from_module(prepare_dirs, mocker):
 
 
 def test_collect_return_false(prepare_dirs, mocker):
-    mocker.patch.object(TestCollector, '_fetch_steps')
+    mocker.patch.object(BehaveTestCollector, '_fetch_steps')
 
-    collector = TestCollector(desc_dir, target_dir)
+    collector = BehaveTestCollector(desc_dir, target_dir)
 
     assert not collector.collect('1', steps_url)
 


### PR DESCRIPTION
The issue was that the search for the behave module was shaded by the `behave.py` file. Added basic test to make sure we can execute tests.