### PR TITLE
add sha512 as an optional checksum

### DIFF
--- a/cekit/cache/cli.py
+++ b/cekit/cache/cli.py
@@ -38,7 +38,7 @@ def ls():
 @click.option('--sha256', metavar="CHECKSUM", help="The sha256 checksum of the artifact.")
 @click.option('--sha512', metavar="CHECKSUM", help="The sha512 checksum of the artifact.")
 def add(location, md5, sha1, sha256, sha512):  # pylint: disable=unused-argument
-    if not (md5 or sha1 or sha256, sha512):
+    if not (md5 or sha1 or sha256 or sha512):
         raise click.UsageError("At least one checksum must be provided")
 
     CacheCli.prepare().add(location, md5, sha1, sha256, sha512)

--- a/cekit/cache/cli.py
+++ b/cekit/cache/cli.py
@@ -36,11 +36,12 @@ def ls():
 @click.option('--md5', metavar="CHECKSUM", help="The md5 checksum of the artifact.")
 @click.option('--sha1', metavar="CHECKSUM", help="The sha1 checksum of the artifact.")
 @click.option('--sha256', metavar="CHECKSUM", help="The sha256 checksum of the artifact.")
-def add(location, md5, sha1, sha256):  # pylint: disable=unused-argument
-    if not (md5 or sha1 or sha256):
+@click.option('--sha512', metavar="CHECKSUM", help="The sha512 checksum of the artifact.")
+def add(location, md5, sha1, sha256, sha512):  # pylint: disable=unused-argument
+    if not (md5 or sha1 or sha256, sha512):
         raise click.UsageError("At least one checksum must be provided")
 
-    CacheCli.prepare().add(location, md5, sha1, sha256)
+    CacheCli.prepare().add(location, md5, sha1, sha256, sha512)
 
 
 @cli.command(name="rm", short_help="Remove artifact from cache")
@@ -70,7 +71,7 @@ class CacheCli():
 
         CONFIG.configure(args.config, {'work_dir': args.work_dir})
 
-    def add(self, location, md5, sha1, sha256):
+    def add(self, location, md5, sha1, sha256, sha512):
         artifact_cache = ArtifactCache()
 
         resource = {}
@@ -84,6 +85,9 @@ class CacheCli():
 
         if sha256:
             resource['sha256'] = sha256
+
+        if sha512:
+            resource['sha512'] = sha512
 
         artifact = Resource(resource)
 

--- a/cekit/crypto.py
+++ b/cekit/crypto.py
@@ -3,7 +3,7 @@ import logging
 
 logger = logging.getLogger('cekit')
 
-SUPPORTED_HASH_ALGORITHMS = ['sha256', 'sha1', 'md5']
+SUPPORTED_HASH_ALGORITHMS = ['sha512', 'sha256', 'sha1', 'md5']
 
 
 def get_sum(target, algorithm):

--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -51,11 +51,12 @@ class Resource(Descriptor):
           md5: {type: str}
           sha1: {type: str}
           sha256: {type: str}
+          sha512: {type: str}
           description: {type: str}
           target: {type: str}
         assert: \"val['git'] is not None or val['path'] is not None or val['url] is not None or val['md5'] is not None\"""")]
         super(Resource, self).__init__(descriptor)
-        self.skip_merging = ['md5', 'sha1', 'sha256']
+        self.skip_merging = ['md5', 'sha1', 'sha256', 'sha512']
 
         # forwarded import to prevent circural imports
         from cekit.cache.artifact import ArtifactCache

--- a/docs/descriptor/includes/artifacts.rst
+++ b/docs/descriptor/includes/artifacts.rst
@@ -18,7 +18,7 @@ Artifact features
 Checksums
     All artifacts will be checked for consistency by computing checksum of
     the downloaded file and comparing it with the desired value. Currently supported algorithms
-    are: ``md5``, ``sha1`` and ``sha256``.
+    are: ``md5``, ``sha1``, ``sha256`` and ``sha512``.
 
     You can define multiple checksums for a single artifact. All specfied checksums will
     be validated.
@@ -79,7 +79,7 @@ Common artifact keys
 
         Target file name: ``jboss-eap-6.4.0.zip``.
 
-``md5``, ``sha1``, ``sha256``
+``md5``, ``sha1``, ``sha256``, ``sha512``
     Checksum algorithms. These keys can be provided to make sure the fetched artifact
     is valid.
 

--- a/docs/handbook/caching.rst
+++ b/docs/handbook/caching.rst
@@ -32,7 +32,7 @@ Example
 Artifacts in cache are **discovered by the hash value**.
 
 While adding an artifact to the cache, CEKit is computing it's checksums for all currently supported algorithms (``md5``,
-``sha1``, ``sha256``). This makes it possible to refer the same artifact in descriptors using different algorithms.
+``sha1``, ``sha256``, ``sha512``). This makes it possible to refer the same artifact in descriptors using different algorithms.
 
 This also means that CEKit is using cache only for artifacts which define **at least one hash**.
 
@@ -69,7 +69,7 @@ Caching artifacts manually
 
 CEKit supports caching artifacts manually. This is very usefull if you need to introduce non-public
 artifact to a CEKit. To cache an artifact you need to specify path to the artifact on filesystem or its URL and
-**at least one** of the supported hashes (``md5``, ``sha1``, ``sha256``).
+**at least one** of the supported hashes (``md5``, ``sha1``, ``sha256``, ``sha512``).
 
 Examples
     Caching local artifact
@@ -97,18 +97,22 @@ After running the command you can see following output:
 
 .. code-block:: yaml
 
-    912c3cc4-7bd3-445d-9927-5063ba3b3bc1:
-        sha256: 04b95a87ee88e1cba7682884ea7f89d5ec097c0fa513e7aca1366d79fb3290a8
-        sha1: 9cbe5393b6837849edbc067fe1a1405ff0c43605
-        md5: f97f623e5b614a7b6d1eb5ff7158027b
-        names:
-            - hawkular-javaagent-1.0.1.Final-redhat-2-shaded.jar
-    7992df2a-be4e-43b5-a02f-18e429ed3ac6:
-        sha256: b2cd21075a4c2a3bc04d2595a1a81ad79d6a36774c28608e04cb73ef76da3458
-        sha1: 9e26ba61c5665aafc849073edeb769be555283cd
-        md5: 080075877a66adf52b7f6d0013fa9730
-        names:
-            - tomcat.tar.gz
+    eba0b8ce-9562-439f-8a56-b9703063a9a3:
+      sha512: 5f4184e0fe7e5c8ae67f5e6bc5deee881051cc712e9ff8aeddf3529724c00e402c94bb75561dd9517a372f06c1fcb78dc7ae65dcbd4c156b3ba4d8e267ec2936
+      sha256: c93c096c8d64062345b26b34c85127a6848cff95a4bb829333a06b83222a5cfa
+      sha1: 3c3231e51248cb76ec97214f6224563d074111c1
+      md5: c1a230474c21335c983f45e84dcf8fb9
+      names:
+        - spark-2.4.0-bin-hadoop2.7.tgz
+
+    dba5a813-3972-4dcf-92a4-87049357f7e0:
+      sha512: cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+      sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      sha1: da39a3ee5e6b4b0d3255bfef95601890afd80709
+      md5: d41d8cd98f00b204e9800998ecf8427e
+      names:
+        - artifact
+
 
 Removing cached artifact
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_unit_resource.py
+++ b/tests/test_unit_resource.py
@@ -325,6 +325,7 @@ def test_overide_resource_remove_chksum():
         md5: 'foo'
         sha1: 'foo'
         sha256: 'foo'
+        sha512: 'foo'
     """), 'foo')
     overrides = Overrides(yaml.safe_load("""
     artifacts:
@@ -338,3 +339,4 @@ def test_overide_resource_remove_chksum():
     assert 'md5' not in overrides['artifacts'][0]
     assert 'sha1' not in overrides['artifacts'][0]
     assert 'sha256' not in overrides['artifacts'][0]
+    assert 'sha512' not in overrides['artifacts'][0]

--- a/tests/test_validate_cache.py
+++ b/tests/test_validate_cache.py
@@ -53,6 +53,7 @@ def test_cekit_cache_add_artifact(tmpdir):
     for alg in SUPPORTED_HASH_ALGORITHMS:
         assert alg in result.output
 
+    assert "sha512: cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e" in result.output
     assert "sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" in result.output
     assert "sha1: da39a3ee5e6b4b0d3255bfef95601890afd80709" in result.output
     assert "md5: d41d8cd98f00b204e9800998ecf8427e" in result.output
@@ -119,9 +120,9 @@ def test_cekit_cannot_add_artifact_without_checksum(tmpdir):
     result = run_cekit_cache(['--work-dir',
                               work_dir,
                               'add',
-                              artifact], 2)
+                              artifact], 1)
 
-    assert "At least one checksum must be provided" in result.output
+    assert "Cannot cache artifact without checksum" in result.output
 
 
 @pytest.mark.parametrize('algorithm', SUPPORTED_HASH_ALGORITHMS)

--- a/tests/test_validate_cache.py
+++ b/tests/test_validate_cache.py
@@ -120,9 +120,9 @@ def test_cekit_cannot_add_artifact_without_checksum(tmpdir):
     result = run_cekit_cache(['--work-dir',
                               work_dir,
                               'add',
-                              artifact], 1)
+                              artifact], 2)
 
-    assert "Cannot cache artifact without checksum" in result.output
+    assert "At least one checksum must be provided" in result.output
 
 
 @pytest.mark.parametrize('algorithm', SUPPORTED_HASH_ALGORITHMS)


### PR DESCRIPTION
This change brings in the `sha512` as a possible key for checksum values
associated with the `artifact` directive. It also updates the relevent
tests and documentation.

closes issue #471 