### PR TITLE
Modules and packages defined in overrides are not ignored anymore

### DIFF
--- a/cekit/descriptor/image.py
+++ b/cekit/descriptor/image.py
@@ -246,7 +246,6 @@ class Image(Descriptor):
             if override.osbs != None:
                 self.osbs = override.osbs.merge(self.osbs)
 
-            # should we really allow overrides to contribute content?
             for package in override.packages.install:
                 if package not in self.packages.install:
                     self.packages.install.append(package)
@@ -271,9 +270,9 @@ class Image(Descriptor):
                 # collect override so we can apply it to modules.
                 # this allows us to override module versions without affecting ordering.
                 module_overrides[name] = module
-                if name in image_modules:
-                    # apply override to image descriptor
-                    image_modules[name] = module
+                # Apply override to image descriptor
+                # If the module does not exists in the original descriptor, add it there
+                image_modules[name] = module
             self.modules._descriptor['install'] = list(image_modules.values())
 
             if override.run != None:

--- a/cekit/descriptor/module.py
+++ b/cekit/descriptor/module.py
@@ -33,4 +33,4 @@ class Module(Image):
 
     @property
     def execute(self):
-        return self.get('execute', [])
+        return self.get('execute')

--- a/cekit/descriptor/modules.py
+++ b/cekit/descriptor/modules.py
@@ -27,11 +27,11 @@ class Modules(Descriptor):
 
     @property
     def repositories(self):
-        return self.get('repositories', [])
+        return self.get('repositories')
 
     @property
     def install(self):
-        return self.get('install', [])
+        return self.get('install')
 
 
 

--- a/cekit/descriptor/packages.py
+++ b/cekit/descriptor/packages.py
@@ -71,17 +71,19 @@ class Packages(Descriptor):
         self._descriptor['repositories'] = [Repository(x)
                                             for x in self._descriptor.get('repositories', [])]
 
+        self._descriptor['install'] = self._descriptor.get('install', [])
+
     @property
     def manager(self):
         return self.get('manager')
 
     @property
     def repositories(self):
-        return self.get('repositories', [])
+        return self.get('repositories')
 
     @property
     def install(self):
-        return self.get('install', [])
+        return self.get('install')
 
     @property
     def content_sets(self):


### PR DESCRIPTION
This fix makes sure that when a package or modules is defined in
overrides only it gets added to the resulting image.

Same applies to artifacts.

Fixes #489