### PR TITLE
backup/restore yum.repos.d when using ContentSets

### DIFF
--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -105,6 +105,10 @@ FROM {{ from }}
 USER root
 {% if packages.repositories_injected %}
 
+# back up existing repo files and clear them out
+RUN cp -a /etc/yum.repos.d /etc/yum.repos.d.cekit-backup
+RUN rm -f /etc/yum.repos.d/*
+
 # Add custom repo files
 COPY {{ repo_create(packages.manager, packages.repositories_injected) }}
 {% endif %}
@@ -151,7 +155,10 @@ RUN {{ repo_clear_cache(packages.manager) }}
 
 {% if packages.repositories_injected %}
 # Remove custom repo files
-RUN {{ repo_remove(packages.manager, packages.repositories_injected) }}
+RUN rm -rf /etc/yum.repos.d
+
+# Restore backed up repo directory
+RUN mv /etc/yum.repos.d.cekit-backup /etc/yum.repos.d
 {% endif %}
 
 # Run user


### PR DESCRIPTION
I don't think you will want this — we discussed the idea in #483 but I don't think you liked it. I'm just raising this FYI as I'm most likely going to use this to build some images now where the base image is shipped with a repo file that is invalid today but will work in the future, as a short term workaround.

---

If we are using ContentSets, back up /etc/yum.repos.d and delete
the contents prior to copying in the ODCS repo file. In clean-up,
delete yum.repos.d again and move the backup back into place.