### PR TITLE
Bump copyright year in the template

### DIFF
--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -77,7 +77,7 @@ VOLUME ["{{ volume['path'] }}"]
 # end {{ module.name }}:{{ module.version }}
 {%- endmacro %}
 
-# Copyright 2017 Red Hat
+# Copyright 2019 Red Hat
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
I wonder, it's a little weird putting RH in the default template, I suppose a future feature might be some way of extracting that and permitting people to inject their own. But so long as its there, let's bump the year