### PR TITLE
Allow for supplementary files to be added to dist-git repository

### DIFF
--- a/cekit/descriptor/image.py
+++ b/cekit/descriptor/image.py
@@ -81,6 +81,10 @@ class Image(Descriptor):
         if not self.packages.manager:
             self.packages._descriptor['manager'] = 'yum'
 
+        # Default directory for supplementary files that should be copied to dist-git directory
+        if not self.osbs.extra_dir:
+            self.osbs._descriptor['extra_dir'] = 'osbs_extra'
+
     @property
     def name(self):
         return self.get('name')

--- a/cekit/descriptor/osbs.py
+++ b/cekit/descriptor/osbs.py
@@ -12,6 +12,8 @@ map:
       name: {type: str}
       branch: {type: str}
   configuration: {type: any}
+  extra_dir: {type: str}
+
 """)]
 
 configuration_schema = [yaml.safe_load("""
@@ -22,11 +24,14 @@ configuration_schema = [yaml.safe_load("""
 
 
 class Osbs(Descriptor):
-    """Object Representing OSBS configuration
+    """
+    Object Representing OSBS configuration
 
     Args:
-      descriptor - yaml containing Osbs object
+      descriptor: dictionary object containing OSBS configuration
+      descriptor_path: path to descriptor file
     """
+
     def __init__(self, descriptor, descriptor_path):
         self.schemas = osbs_schema
         self.descriptor_path = descriptor_path
@@ -54,6 +59,15 @@ class Osbs(Descriptor):
     @property
     def configuration(self):
         return self.get('configuration')
+
+    @property
+    def extra_dir(self):
+        return self.get('extra_dir')
+
+    @extra_dir.setter
+    def extra_dir(self, value):
+        self._descriptor['extra_dir'] = value
+
 
 class Configuration(Descriptor):
     """Internal object represeting OSBS configuration subObject

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -56,6 +56,9 @@ class Generator(object):
         Initializes the image object.
         """
 
+        LOGGER.debug("Removing old target directory")
+        shutil.rmtree(self.target, ignore_errors=True)
+
         # Read the main image descriptor and create an Image object from it
         descriptor = tools.load_descriptor(self._descriptor_path)
         self.image = Image(descriptor, os.path.dirname(os.path.abspath(self._descriptor_path)))

--- a/cekit/generator/osbs.py
+++ b/cekit/generator/osbs.py
@@ -6,7 +6,7 @@ import yaml
 from cekit.config import Config
 from cekit.descriptor.resource import _PlainResource
 from cekit.generator.base import Generator
-from cekit.tools import get_brew_url
+from cekit.tools import get_brew_url, copy_recursively
 
 logger = logging.getLogger('cekit')
 config = Config()
@@ -21,6 +21,18 @@ class OSBSGenerator(Generator):
         super(OSBSGenerator, self).init()
 
         self._prepare_container_yaml()
+
+    def generate(self, builder):
+        # If extra directory exists (by default named 'osbs_extra') next to
+        # the image descriptor, copy it contents to the target directory.
+        #
+        # https://github.com/cekit/cekit/issues/394
+        copy_recursively(
+            os.path.join(os.path.dirname(self._descriptor_path), self.image.osbs.extra_dir),
+            os.path.join(self.target, 'image')
+        )
+
+        super(OSBSGenerator, self).generate(builder)
 
     def _prepare_content_sets(self, content_sets):
         content_sets_f = os.path.join(self.target, 'image', 'content_sets.yml')

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import subprocess
 import sys
 
@@ -127,6 +128,39 @@ def get_brew_url(md5):
                      ex.output)
         raise ex
     return url
+
+
+def copy_recursively(source_directory, destination_directory):
+    """
+    Copies contents of a directory to selected target location (also a directory).
+    the specific source file to destination.
+
+    If the source directory contains a directory, it will copy all the content recursively.
+    Symlinks are preserved (not followed).
+
+    The destination directory tree will be created if it does not exist.
+    """
+
+    # If the source directory does not exists, return
+    if not os.path.isdir(source_directory):
+        return
+
+    # Iterate over content in the source directory
+    for name in os.listdir(source_directory):
+        src = os.path.join(source_directory, name)
+        dst = os.path.join(destination_directory, name)
+
+        LOGGER.debug("Copying '{}' to '{}'...".format(src, dst))
+
+        if not os.path.isdir(os.path.dirname(dst)):
+            os.makedirs(os.path.dirname(dst))
+
+        if os.path.islink(src):
+            os.symlink(os.readlink(src), dst)
+        elif os.path.isdir(src):
+            shutil.copytree(src, dst, symlinks=True)
+        else:
+            shutil.copy2(src, dst)
 
 
 class Chdir(object):

--- a/docs/descriptor/includes/image/osbs.rst
+++ b/docs/descriptor/includes/image/osbs.rst
@@ -26,6 +26,30 @@ It contains two main keys:
                 compose:
                     pulp_repos: true
 
+OSBS extra directory
+^^^^^^^^^^^^^^^^^^^^^
+
+Key
+    ``extra_dir``
+Required
+    No
+
+If a directory name specified by ``extra_dir`` key will be found next to the image descriptor, the contents of this directory
+will be copied into the target directory and later to the dist-git directory.
+
+Symbolic links are preserved (not followed).
+
+Copying files is done before generation, which means that files from the extra directory can be overridden
+in the :ref:`generation phase<handbook/building/build-process:Generating required files>` .
+
+.. note::
+    If you do not specify this key in image descriptor, the default value of ``osbs_extra`` will be used.
+
+.. code-block:: yaml
+
+    osbs:
+        extra_dir: custom-files
+
 OSBS repository
 ^^^^^^^^^^^^^^^^
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -136,7 +136,7 @@ def test_merge_container_yaml_limit_arch(mocker, tmpdir):
 
 
 class DistGitMock(object):
-    def add(self):
+    def add(self, artifacts):
         pass
 
     def stage_modified(self):
@@ -414,7 +414,7 @@ def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
 
     mocker.patch('cekit.tools.DependencyHandler.handle')
     mocker.patch('cekit.descriptor.resource.Resource.copy')
-    copy_mock = mocker.patch('cekit.builders.osbs.shutil.copy')
+    copy_mock = mocker.patch('cekit.builders.osbs.shutil.copy2')
 
     dist_git_class = mocker.patch('cekit.builders.osbs.DistGit')
     dist_git_class.return_value = DistGitMock()
@@ -448,10 +448,10 @@ def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
     dist_git_class.assert_called_once_with(os.path.join(
         str(tmpdir), 'osbs', 'repo'), str(tmpdir), 'repo', 'branch')
 
-    calls = [mocker.call('Dockerfile', os.path.join(str(tmpdir), 'osbs/repo/Dockerfile')),
-             mocker.call(os.path.join(str(tmpdir), src), os.path.join(str(tmpdir), target))]
-
-    copy_mock.assert_has_calls(calls)
+    copy_mock.assert_has_calls([
+        mocker.call(os.path.join(str(tmpdir), 'image', 'Dockerfile'),
+                    os.path.join(str(tmpdir), 'osbs/repo/Dockerfile'))
+    ])
 
 
 def test_docker_builder_defaults():

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -113,6 +113,7 @@ def test_dockerfile_rendering(tmpdir, mocker, name, desc_part, exp_regex):
                          ids=print_test_name)
 def test_dockerfile_rendering_tech_preview(tmpdir, mocker, desc_part, exp_regex):
     mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
 
@@ -139,6 +140,7 @@ def test_dockerfile_docker_odcs_rpm(tmpdir, mocker):
     mocker.patch.object(subprocess, 'check_output', return_value=odcs_fake_resp)
     mocker.patch.object(Repository, 'fetch')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
 
     target = str(tmpdir.mkdir('target'))
@@ -171,6 +173,7 @@ def test_dockerfile_osbs_odcs_pulp(tmpdir, mocker):
     mocker.patch.object(subprocess, 'check_output', return_value=odcs_fake_resp)
     mocker.patch.object(Repository, 'fetch')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     config.cfg['common'] = {'redhat': True}
 
@@ -194,6 +197,7 @@ def test_dockerfile_osbs_odcs_pulp_no_redhat(tmpdir, mocker):
     mocker.patch.object(subprocess, 'check_output', return_value=odcs_fake_resp)
     mocker.patch.object(Repository, 'fetch')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     config.cfg['common'] = {'redhat': False}
 
@@ -216,6 +220,7 @@ def test_dockerfile_osbs_id_redhat_false(tmpdir, mocker):
     mocker.patch.object(subprocess, 'check_output', return_value=odcs_fake_resp)
     mocker.patch.object(Repository, 'fetch')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'repositories': [{'name': 'foo',
@@ -233,6 +238,7 @@ def test_dockerfile_osbs_url_only(tmpdir, mocker):
     mocker.patch.object(subprocess, 'check_output', return_value=odcs_fake_resp)
     mocker.patch.object(Repository, 'fetch')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'repositories': [{'name': 'foo',


### PR DESCRIPTION
If a directory called `dist` is found next to the image descriptor,
contents of this directory will be copied to the **root** of the
dist-git directory.

Fixes #394.