### PR TITLE
Add support for validating image sources

### DIFF
--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -80,10 +80,10 @@ class OSBSBuilder(Builder):
 
         return deps
 
-    def before_run(self):
+    def before_build(self):
         """Prepares dist-git repository for OSBS build."""
 
-        super(OSBSBuilder, self).before_run()
+        super(OSBSBuilder, self).before_build()
 
         self.prepare_dist_git()
         self.copy_to_dist_git()

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -55,10 +55,11 @@ def cli(descriptor, verbose, work_dir, config, redhat, target):  # pylint: disab
 
 
 @cli.group(short_help="Build container image")
+@click.option('--validate', help="Do not execute the build nor generate files, just validate image and module descriptors.", is_flag=True)
 @click.option('--dry-run', help="Do not execute the build, just generate required files.", is_flag=True)
 @click.option('--overrides', metavar="JSON", help="Inline overrides in JSON format.", multiple=True)
 @click.option('--overrides-file', 'overrides', metavar="PATH", help="Path to overrides file in YAML format.", multiple=True)
-def build(dry_run, overrides):  # pylint: disable=unused-argument
+def build(validate, dry_run, overrides):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/docs/handbook/building/parameters.rst
+++ b/docs/handbook/building/parameters.rst
@@ -4,10 +4,19 @@ Common build parameters
 Below you can find description of the common parameters that can be added to every build
 command.
 
+``--validate``
+    Do not generate files nor execute the build but prepare image sources and
+    check if these are valid. Useful when you just want to make sure that the
+    content is buildable.
+
+    See ``--dry-run``.
+
 ``--dry-run``
-    Does not execute the actual build but let's CEKit prepare all required files to
-    be able to build the image. This is very handy when you want manually check generated
-    content.
+    Do not execute the build but let's CEKit prepare all required files to
+    be able to build the image for selected builder engine. This is very handy
+    when you want manually check generated content.
+
+    See ``--validate``.
 
 ``--overrides``
     Allows to specify overrides content as a JSON formatted string, directly

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -444,7 +444,9 @@ def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
 
     with mocker.patch('cekit.tools.get_brew_url', side_effect=subprocess.CalledProcessError(1, 'command')):
         builder.prepare()
-        builder.before_run()
+        builder.before_generate()
+        builder.generate()
+        builder.before_build()
 
     dist_git_class.assert_called_once_with(os.path.join(
         str(tmpdir), 'osbs', 'repo'), str(tmpdir), 'repo', 'branch')

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -26,7 +26,7 @@ def get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': True, 'target': 'target'
         },
         {
-            'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
         }
     ),
     # Check custom target
@@ -37,7 +37,7 @@ def get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': False, 'target': 'custom-target'
         },
         {
-            'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
         }
     ),
     # Check custom work dir
@@ -48,7 +48,7 @@ def get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': 'custom-workdir', 'config': '~/.cekit/config', 'redhat': False, 'target': 'target'
         },
         {
-            'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
         }
     ),
     # Check custom config file
@@ -59,7 +59,7 @@ def get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': 'custom-config', 'redhat': False, 'target': 'target'
         },
         {
-            'dry_run': False, 'overrides': (),  'pull': False, 'no_squash': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': (),  'pull': False, 'no_squash': False, 'tags': ()
         }
     ),
     # Test default values for Docker builder
@@ -68,7 +68,7 @@ def get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
         }
     ),
     # Test overrides
@@ -77,7 +77,7 @@ def get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         None,
         {
-            'dry_run': False, 'overrides': ('foo', 'bar'), 'pull': False, 'no_squash': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': ('foo', 'bar'), 'pull': False, 'no_squash': False, 'tags': ()
         }
     ),
     # Test default values for OSBS builder
@@ -86,7 +86,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
+            'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
         }
     ),
     # Test setting user for OSBS
@@ -95,7 +95,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'commit_message': None
+            'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'commit_message': None
         }
     ),
     # Test setting stage environment for OSBS
@@ -104,7 +104,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None
+            'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None
         }
     ),
     # Test setting nowait for OSBS
@@ -113,7 +113,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': True, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
+            'validate': False, 'dry_run': False, 'overrides': (), 'nowait': True, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
         }
     ),
     (
@@ -131,7 +131,7 @@ def get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'pull': True, 'no_squash': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': (), 'pull': True, 'no_squash': False, 'tags': ()
         }
     ),
     (
@@ -139,14 +139,14 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'release': False, 'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None
+            'validate': False, 'dry_run': False, 'overrides': (), 'release': False, 'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None
         }),
     (
         ['build', 'docker'],
         'cekit.builders.docker_builder.DockerBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'no_squash': False, 'tags': ()
         }
     ),
     (
@@ -154,7 +154,7 @@ def get_class_by_name(clazz):
         'cekit.builders.buildah.BuildahBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'pull': False, 'tags': ()
+            'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'tags': ()
         }
     )
 ])


### PR DESCRIPTION
This adds a --validate switch to the build command. It interrupts the build process
early in the stage, just after the model is prepared and validated. This
is similar to --dry-run with the difference that --dry-run additionally generates
required files for the selected builder (which --validate does not).

This required redesigning build hooks which are now following:

1. prepare()
2. before_generate()
3. generate()
4. before_build()
5. run()

Fixes #551