### PR TITLE
[KEYCLOAK-10694] Add workaround for microdnf RH BZ#1700341 issue

### DIFF
--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -19,6 +19,9 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
 {% macro pkg_install(pkg_manager, packages) -%}
     {% if pkg_manager in helper.SUPPORTED_PACKAGE_MANAGERS %}
 {{ pkg_manager }} --setopt=tsflags=nodocs install -y {%- for package in packages %} {{ package }}{% endfor %} \
+    {% if pkg_manager == 'microdnf' %}
+    && {{ pkg_manager }} clean all \
+    {% endif %}
     && rpm -q{% for package in packages %} {{ package }}{% endfor %}
     {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
Per https://github.com/rpm-software-management/microdnf/issues/27 libdnf seems to have an issue on cache data, when doing multiple / subsequent package installs

Therefore clean the microdnf cache after the each install command
to avoid this

Also add a test to check the 'clean all' snippet is present in resulting Dockerfile, when using microdnf as a package manager

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>