### PR TITLE
Copy modules and artifacts when module is processed

### DIFF
--- a/cekit/descriptor/image.py
+++ b/cekit/descriptor/image.py
@@ -276,9 +276,8 @@ class Image(Descriptor):
                 artifact_overrides[name] = artifact
                 # add it to the list of everything
                 self._all_artifacts[name] = artifact
-                if name in image_artifacts:
-                    # apply override to image descriptor
-                    image_artifacts[name] = artifact
+                # Apply override to image descriptor
+                image_artifacts[name] = artifact
             self._descriptor['artifacts'] = list(image_artifacts.values())
 
             module_overrides = self._image_overrides['modules']

--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -262,7 +262,7 @@ class _PathResource(Resource):
         if os.path.isdir(self.path):
             shutil.copytree(self.path, target)
         else:
-            shutil.copy(self.path, target)
+            shutil.copy2(self.path, target)
         return target
 
 

--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -30,12 +30,29 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
 {{ pkg_manager }} clean all && [ ! -d /var/cache/yum ] || rm -rf /var/cache/yum
     {% endif %}
 {%- endmacro %}
-{% macro process_module(module) %}
-# begin {{ module.name }}:{{ module.version }}
-{% if module.packages and module.packages.install %}
+{%- macro process_image(image) %}
+{{ process_module(image, image=true) }}
+{%- endmacro %}
+{% macro process_module(module, image=false) %}
+# START module {{ module.name }}:{{ module.version }}
 
-# Install required RPMs and ensure that the packages were installed
+{% if module.artifacts|length > 0 %}
+# Copy module {{ module.name }} artifacts
+COPY \
+{% for artifact in module.artifacts %}
+    {{ artifact['target'] }} \
+    {% endfor %}
+    /tmp/artifacts/
+{% endif %}
+
+{%- if not image %}
+# Copy module {{ module.name }} content
+COPY modules/{{ module.name }} /tmp/scripts/{{ module.name }}
+{% endif %}
+
+{% if module.packages and module.packages.install %}
 USER root
+
 RUN {{ pkg_install(packages.manager, module.packages.install) }}
 {% endif %}
 {% if helper.envs(module.envs)|length > 0 %}
@@ -77,7 +94,7 @@ VOLUME ["{{ volume['path'] }}"]
 {% endfor %}
 {% endif %}
 
-# end {{ module.name }}:{{ module.version }}
+# END module {{ module.name }}:{{ module.version }}
 {%- endmacro %}
 
 # Copyright 2019 Red Hat
@@ -115,24 +132,10 @@ RUN {{ repo_install(packages.manager, repo.rpm) }}
 {% endfor %}
 {% endif %}
 
-{% if image.modules.install|length > 0 %}
-# Add scripts used to configure the image
-COPY modules /tmp/scripts/
-{% endif %}
-
-{% if image.all_artifacts|length > 0 %}
-# Add all artifacts to the /tmp/artifacts directory
-COPY \
-{% for artifact in image.all_artifacts %}
-    {{ artifact['target'] }} \
-    {% endfor %}
-    /tmp/artifacts/
-{% endif %}
-
 {% for to_install in image.modules.install %}
 {{ process_module(helper.module(to_install)) }}
 {% endfor %}
-{{ process_module(image) }}
+{{ process_image(image) }}
 
 USER root
 RUN [ ! -d /tmp/scripts ] || rm -rf /tmp/scripts

--- a/docs/guidelines/local-development.rst
+++ b/docs/guidelines/local-development.rst
@@ -61,8 +61,8 @@ When your work is finished, commit and push your changes to a module repository.
 Injecting local artifacts
 ----------------------------
 
-During module/image development there can be a need to use locally built artifact instead of a released one. The easiest way to inject
-such artifact is to use override mechanism.
+During module/image development there can be a need to use locally built artifact instead of a released one.
+The easiest way to inject such artifact is to use override mechanism.
 
 Imagine that you have an artifact defined in following way:
 
@@ -93,3 +93,35 @@ pass integrity checks you need to define checksum also in overrides in a followi
           md5: d31c6b1525e6d2d24062ef26a9f639a8
           path: /tmp/build/joloika.jar
 
+Using Docker cache
+--------------------
+
+.. versionadded:: 3.3.0
+
+Docker has support for caching layers. This is very convenient when you are developing images. It saves time by
+not rebuilding the whole image on any change, but instead it rebuilds layers that were changed only.
+
+You can read more about it `in Docker's documentation <https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache>`__.
+
+In version ``3.3.0`` CEKit we optimized the way we generate Dockerfile making it much easier to fully
+leverage the caching mechanism.
+
+In order to make most of this feature we strongly suggest to execute Docker build with the the ``--no-squash``
+parameter. This will make sure that the intermediate layers won't be removed. In other case, the
+squashing post-processing will take place and any intermediate layers will be cleaned afterwards
+effectively losing cached layers.
+
+.. code-block:: bash
+
+    $ cekit build docker --no-squash
+
+.. warning::
+
+    You need to be aware that rebuilding a Docker image numerous times with the ``--no-squash``
+    option will leave many dangling layers that could fill your Docker storage. To prevent
+    this you need to remove unused images from time to time. The ``docker system prune -a`` command
+    may be useful.
+
+.. note::
+    Please note that ``--no-squash`` switch may be only useful when developing the image.
+    We strongly suggest to not use it to build the final image.

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -387,7 +387,7 @@ def test_dockerfile_copy_modules_if_modules_defined(tmpdir, caplog):
                                                        'path': 'modules'}],
                                      'install': [{'name': 'foo'}]}})
 
-    regex_dockerfile(target, 'COPY modules /tmp/scripts/')
+    regex_dockerfile(target, 'COPY modules/foo /tmp/scripts/foo')
 
 
 def generate(image_dir, command, descriptor=None, exit_code=0):

--- a/tests/test_unit_resource.py
+++ b/tests/test_unit_resource.py
@@ -201,7 +201,7 @@ def test_path_resource_relative():
 def test_path_local_existing_resource_no_cacher_use(mocker):
     config.cfg['common']['cache_url'] = '#filename#,#algorithm#,#hash#'
     mocker.patch('os.path.exists', return_value=True)
-    shutil_mock = mocker.patch('shutil.copy')
+    shutil_mock = mocker.patch('shutil.copy2')
 
     res = Resource({'name': 'foo',
                     'path': 'bar'}, directory='/foo')

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -654,7 +654,11 @@ def test_execution_order(tmpdir):
     run_cekit(image_dir)
 
     expected_modules_order = """
-# begin child_of_child:None
+# START module child_of_child:None
+
+# Copy module child_of_child content
+COPY modules/child_of_child /tmp/scripts/child_of_child
+
 
 # Environment variables
 ENV \\
@@ -664,22 +668,34 @@ ENV \\
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/child_of_child/script_d" ]
 
-# end child_of_child:None
-# begin child2_of_child:None
+# END module child_of_child:None
+# START module child2_of_child:None
+
+# Copy module child2_of_child content
+COPY modules/child2_of_child /tmp/scripts/child2_of_child
+
 
 # Custom scripts
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/child2_of_child/scripti_e" ]
 
-# end child2_of_child:None
-# begin child3_of_child:None
+# END module child2_of_child:None
+# START module child3_of_child:None
+
+# Copy module child3_of_child content
+COPY modules/child3_of_child /tmp/scripts/child3_of_child
+
 
 # Custom scripts
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/child3_of_child/script_f" ]
 
-# end child3_of_child:None
-# begin child:None
+# END module child3_of_child:None
+# START module child:None
+
+# Copy module child content
+COPY modules/child /tmp/scripts/child
+
 
 # Environment variables
 ENV \\
@@ -689,32 +705,52 @@ ENV \\
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/child/script_b" ]
 
-# end child:None
-# begin child_2:None
+# END module child:None
+# START module child_2:None
+
+# Copy module child_2 content
+COPY modules/child_2 /tmp/scripts/child_2
+
 
 # Custom scripts
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/child_2/script_c" ]
 
-# end child_2:None
-# begin child_of_child3:None
+# END module child_2:None
+# START module child_of_child3:None
+
+# Copy module child_of_child3 content
+COPY modules/child_of_child3 /tmp/scripts/child_of_child3
+
 
 # Custom scripts
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/child_of_child3/script_g" ]
 
-# end child_of_child3:None
-# begin child2_of_child3:None
+# END module child_of_child3:None
+# START module child2_of_child3:None
+
+# Copy module child2_of_child3 content
+COPY modules/child2_of_child3 /tmp/scripts/child2_of_child3
+
 
 # Custom scripts
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/child2_of_child3/script_h" ]
 
-# end child2_of_child3:None
-# begin child_3:None
+# END module child2_of_child3:None
+# START module child_3:None
 
-# end child_3:None
-# begin master:None
+# Copy module child_3 content
+COPY modules/child_3 /tmp/scripts/child_3
+
+
+# END module child_3:None
+# START module master:None
+
+# Copy module master content
+COPY modules/master /tmp/scripts/master
+
 
 # Environment variables
 ENV \\
@@ -724,7 +760,7 @@ ENV \\
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/master/script_a" ]
 
-# end master:None
+# END module master:None
 """
     assert check_dockerfile_text(image_dir, expected_modules_order)
 
@@ -784,7 +820,11 @@ def test_execution_order_flat(tmpdir, mocker):
     run_cekit(image_dir)
 
     expected_modules_order = """
-# begin mod_1:None
+# START module mod_1:None
+
+# Copy module mod_1 content
+COPY modules/mod_1 /tmp/scripts/mod_1
+
 
 # Environment variables
 ENV \\
@@ -798,8 +838,12 @@ RUN [ "bash", "-x", "/tmp/scripts/mod_1/b" ]
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/mod_1/c" ]
 
-# end mod_1:None
-# begin mod_2:None
+# END module mod_1:None
+# START module mod_2:None
+
+# Copy module mod_2 content
+COPY modules/mod_2 /tmp/scripts/mod_2
+
 
 # Environment variables
 ENV \\
@@ -813,8 +857,12 @@ RUN [ "bash", "-x", "/tmp/scripts/mod_2/b" ]
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/mod_2/c" ]
 
-# end mod_2:None
-# begin mod_3:None
+# END module mod_2:None
+# START module mod_3:None
+
+# Copy module mod_3 content
+COPY modules/mod_3 /tmp/scripts/mod_3
+
 
 # Custom scripts
 USER root
@@ -824,8 +872,12 @@ RUN [ "bash", "-x", "/tmp/scripts/mod_3/b" ]
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/mod_3/c" ]
 
-# end mod_3:None
-# begin mod_4:None
+# END module mod_3:None
+# START module mod_4:None
+
+# Copy module mod_4 content
+COPY modules/mod_4 /tmp/scripts/mod_4
+
 
 # Custom scripts
 USER root
@@ -835,7 +887,7 @@ RUN [ "bash", "-x", "/tmp/scripts/mod_4/b" ]
 USER root
 RUN [ "bash", "-x", "/tmp/scripts/mod_4/c" ]
 
-# end mod_4:None
+# END module mod_4:None
 """
     assert check_dockerfile_text(image_dir, expected_modules_order)
     assert not check_dockerfile_text(image_dir, "RUN yum clean all")
@@ -856,22 +908,28 @@ def test_package_related_commands_packages_in_module(tmpdir, mocker):
     run_cekit(image_dir)
 
     expected_packages_order_install = """
-# begin packages_module:None
+# START module packages_module:None
 
-# Install required RPMs and ensure that the packages were installed
+# Copy module packages_module content
+COPY modules/packages_module /tmp/scripts/packages_module
+
 USER root
+
 RUN yum --setopt=tsflags=nodocs install -y kernel java \\
     && rpm -q kernel java
 
-# end packages_module:None
-# begin packages_module_1:None
+# END module packages_module:None
+# START module packages_module_1:None
 
-# Install required RPMs and ensure that the packages were installed
+# Copy module packages_module_1 content
+COPY modules/packages_module_1 /tmp/scripts/packages_module_1
+
 USER root
+
 RUN yum --setopt=tsflags=nodocs install -y wget mc \\
     && rpm -q wget mc
 
-# end packages_module_1:None
+# END module packages_module_1:None
 """
 
     assert check_dockerfile_text(image_dir, expected_packages_order_install)
@@ -892,8 +950,8 @@ def test_package_related_commands_packages_in_image(tmpdir, mocker):
     run_cekit(image_dir)
 
     expected_packages_install = """
-# Install required RPMs and ensure that the packages were installed
 USER root
+
 RUN yum --setopt=tsflags=nodocs install -y wget mc \\
     && rpm -q wget mc
 """


### PR DESCRIPTION
This chnges the way we generate Dockerfile so that
artifacts and modules are not copied at the beginning of
the Dockerfile. This makes it possible to reuse
Docker (and other builder's) cache for content that
was not changed.

To make use of rapid development with cached you need to
make sure the module you modify is installed later in the process
because this invalidates cache and all modules installed
later will need to be executed again.

If you use Docker builder, use the `--no-squash` option.
Without this, the squash post processing will remove all
intermediate container images created at the original image build time
removing the cache at the same time.

Fixes #544