### PR TITLE
Improve logging - show less warnings

### DIFF
--- a/cekit/descriptor/execute.py
+++ b/cekit/descriptor/execute.py
@@ -23,13 +23,14 @@ class Execute(Descriptor):
         super(Execute, self).__init__(descriptor)
 
         descriptor['directory'] = module_name
-
         descriptor['module_name'] = module_name
 
         if 'name' not in descriptor:
-            logger.warning("No value found for 'name'; using auto-generated value of {}/{}".
-                           format(module_name, descriptor['script']))
-            descriptor['name'] = "%s/%s" % (module_name, descriptor['script'])
+            # Generated name
+            descriptor['name'] = "{}/{}".format(module_name, descriptor['script'])
+
+            logger.debug("No value found for 'name' key in the execute section of the '{}' module; using auto-generated value: '{}'".format(
+                module_name, descriptor['name']))
 
     @property
     def name(self):

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -182,8 +182,9 @@ class Generator(object):
         """
         target = os.path.join(self.target, 'image', 'modules')
         for module in self.image.modules.install:
-            module = self._module_registry.get_module(module.name, module.version)
-            LOGGER.debug("Copying module '{}' required by '{}'.".format(module.name, self.image.name))
+            module = self._module_registry.get_module(module.name, module.version, suppress_warnings=True)
+            LOGGER.debug("Copying module '{}' required by '{}'.".format(
+                module.name, self.image.name))
 
             dest = os.path.join(target, module.name)
 
@@ -448,7 +449,7 @@ class ModuleRegistry(object):
         self._modules = {}
         self._defaults = {}
 
-    def get_module(self, name, version=None):
+    def get_module(self, name, version=None, suppress_warnings=False):
         """
         Returns the module available in registry based on the name and version requested.
 
@@ -486,8 +487,9 @@ class ModuleRegistry(object):
 
             default_module = self.get_module(name, default_version)
 
-            LOGGER.warning("Module version not specified for '{}' module, using '{}' default version".format(
-                name, default_version))
+            if not suppress_warnings:
+                LOGGER.warning("Module version not specified for '{}' module, using '{}' default version".format(
+                    name, default_version))
 
             return default_module
 

--- a/cekit/template_helper.py
+++ b/cekit/template_helper.py
@@ -9,7 +9,7 @@ class TemplateHelper(object):
         self._module_registry = module_registry
 
     def module(self, to_install):
-        return self._module_registry.get_module(to_install.name, to_install.version)
+        return self._module_registry.get_module(to_install.name, to_install.version, suppress_warnings=True)
 
     def packages_to_install(self, image):
         """


### PR DESCRIPTION
This shows less warning, especially for modules without version specified. Without this change it would be printed 3 times. Additionally changes logging level to debug for missing name in scripts. We do not want to spam users with it.