### PR TITLE
Add support for syncing with dist-git without running an OSBS build

### DIFF
--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -145,9 +145,10 @@ def build_podman(ctx, pull, tags):  # pylint: disable=unused-argument
 @click.option('--nowait', help="Do not wait for the task to finish.", is_flag=True)
 @click.option('--stage', help="Use stage environmen.", is_flag=True)
 @click.option('--koji-target', metavar="TARGET", help="Override the default Koji target.")
+@click.option('--sync-only', help="Generate files and sync with dist-git, but do not execute build.", is_flag=True)
 @click.option('--commit-message', metavar="MESSAGE", help="Custom dist-git commit message.")
 @click.pass_context
-def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, commit_message):  # pylint: disable=unused-argument
+def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/docs/handbook/building/builder-engines.rst
+++ b/docs/handbook/building/builder-engines.rst
@@ -123,6 +123,7 @@ Parameters
     * ``--stage`` -- use stage environment
     * ``--koji-target`` -- overrides the default ``koji`` target
     * ``--commit-message`` -- custom commit message for dist-git
+    * ``--sync-only`` -- generate files and sync with dist-git, but do not execute build
 
 Example
     Performing scratch build

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -410,6 +410,7 @@ def test_osbs_wait_for_osbs_task_failed(mocker):
 def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
     os.makedirs(os.path.join(str(tmpdir), 'image'))
 
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.tools.DependencyHandler.handle')
     mocker.patch('cekit.descriptor.resource.Resource.copy')
     copy_mock = mocker.patch('cekit.builders.osbs.shutil.copy2')
@@ -481,8 +482,8 @@ def test_osbs_dist_git_sync_called(mocker, tmpdir):
     builder = create_builder_object(
         mocker, 'osbs', {}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
-    prepare_dist_git = mocker.patch.object(builder, 'prepare_dist_git')
-    copy_to_dist_git = mocker.patch.object(builder, 'copy_to_dist_git')
+    prepare_dist_git = mocker.patch.object(builder, '_prepare_dist_git')
+    copy_to_dist_git = mocker.patch.object(builder, '_copy_to_dist_git')
     run = mocker.patch.object(builder, 'run')
 
     builder.execute()
@@ -512,14 +513,16 @@ def test_osbs_dist_git_sync_NOT_called_when_dry_run_set(mocker, tmpdir):
     builder = create_builder_object(
         mocker, 'osbs', {'dry_run': True}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
-    prepare_dist_git = mocker.patch.object(builder, 'prepare_dist_git')
-    copy_to_dist_git = mocker.patch.object(builder, 'copy_to_dist_git')
+    prepare_dist_git = mocker.patch.object(builder, '_prepare_dist_git')
+    copy_to_dist_git = mocker.patch.object(builder, '_copy_to_dist_git')
+    sync_with_dist_git = mocker.patch.object(builder, '_sync_with_dist_git')
     run = mocker.patch.object(builder, 'run')
 
     builder.execute()
 
     prepare_dist_git.assert_not_called()
     copy_to_dist_git.assert_not_called()
+    sync_with_dist_git.assert_not_called()
     run.assert_not_called()
 
 

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -88,8 +88,9 @@ def test_dockerfile_rendering(tmpdir, mocker, name, desc_part, exp_regex):
                          ],
                          ids=print_test_name)
 def test_dockerfile_rendering_tech_preview(tmpdir, mocker, desc_part, exp_regex):
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
 
@@ -102,7 +103,7 @@ def test_dockerfile_docker_odcs_pulp(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
     mocker.patch('cekit.generator.docker.DockerGenerator.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'content_sets': {
@@ -119,8 +120,9 @@ def test_dockerfile_docker_odcs_rpm(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
 
     target = str(tmpdir.mkdir('target'))
@@ -156,8 +158,9 @@ def test_dockerfile_osbs_odcs_pulp(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     config.cfg['common'] = {'redhat': True}
 
@@ -182,8 +185,9 @@ def test_dockerfile_osbs_odcs_pulp_no_redhat(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     config.cfg['common'] = {'redhat': False}
 
@@ -207,8 +211,9 @@ def test_dockerfile_osbs_id_redhat_false(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'repositories': [{'name': 'foo',
@@ -227,8 +232,9 @@ def test_dockerfile_osbs_url_only(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'repositories': [{'name': 'foo',

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -83,7 +83,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None
         }
     ),
     # Test setting user for OSBS
@@ -93,7 +93,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None,
+            'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'sync_only': False,
             'commit_message': None
         }
     ),
@@ -104,7 +104,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'sync_only': False, 'commit_message': None
         }
     ),
     # Test setting nowait for OSBS
@@ -114,7 +114,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': True,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None
         }
     ),
     (
@@ -141,7 +141,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'release': False,
-            'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None
+            'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None
         }),
     (
         ['build', 'docker'],


### PR DESCRIPTION
Add a --sync-only parameter to the OSBS builder engine. When specified
the content will be generated, synced with dist git and afterwards
the process will be stopped meaning that the OSBS build will
not be trigerred.

Fixes #587