### PR TITLE
Add --assume-yes (-y) switch to OSBS builder

### DIFF
--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -113,7 +113,8 @@ class OSBSBuilder(Builder):
         self.dist_git = DistGit(self.dist_git_dir,
                                 self.target,
                                 repository,
-                                branch)
+                                branch,
+                                self.params.assume_yes)
 
         self.dist_git.prepare(self.params.stage, self.params.user)
         self.dist_git.clean()
@@ -267,7 +268,7 @@ class OSBSBuilder(Builder):
 
             LOGGER.info("About to execute '{}'.".format(' '.join(cmd)))
 
-            if tools.decision("Do you want to build the image in OSBS?"):
+            if self.params.assume_yes or tools.decision("Do you want to build the image in OSBS?"):
                 build_type = "scratch" if scratch else "release"
                 LOGGER.info("Executing {} container build in OSBS...".format(build_type))
 

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -147,8 +147,9 @@ def build_podman(ctx, pull, tags):  # pylint: disable=unused-argument
 @click.option('--koji-target', metavar="TARGET", help="Override the default Koji target.")
 @click.option('--sync-only', help="Generate files and sync with dist-git, but do not execute build.", is_flag=True)
 @click.option('--commit-message', metavar="MESSAGE", help="Custom dist-git commit message.")
+@click.option('--assume-yes', '-y', help="Execute build in non-interactive mode.", is_flag=True)
 @click.pass_context
-def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message):  # pylint: disable=unused-argument
+def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message, assume_yes):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/docs/handbook/building/builder-engines.rst
+++ b/docs/handbook/building/builder-engines.rst
@@ -19,9 +19,12 @@ This builder uses Docker daemon as the build engine. Interaction with Docker dae
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
-    * ``--no-squash`` -- do not squash the image after build is done.
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
+    ``--no-squash``
+        Do not squash the image after build is done.
 
 Example
     Building Docker image
@@ -116,14 +119,32 @@ it performs **scratch build**. If you need a proper build you need to specify ``
 Input format
     Dockerfile
 Parameters
-    * ``--release`` -- perform an OSBS release build
-    * ``--tech-preview`` -- build tech preview image, see :ref:`below for more information <handbook/building/builder-engines:Tech preview images>`
-    * ``--user`` -- alternative user passed to build task
-    * ``--nowait`` -- do not wait for the task to finish
-    * ``--stage`` -- use stage environment
-    * ``--koji-target`` -- overrides the default ``koji`` target
-    * ``--commit-message`` -- custom commit message for dist-git
-    * ``--sync-only`` -- generate files and sync with dist-git, but do not execute build
+    ``--release``
+        Perform an OSBS release build
+    ``--tech-preview``
+        Build tech preview image, see
+        :ref:`below for more information <handbook/building/builder-engines:Tech preview images>`
+    ``--user``
+        Alternative user passed to build task
+    ``--nowait``
+        Do not wait for the task to finish
+    ``--stage``
+        Use stage environment
+    ``--koji-target``
+        Overrides the default ``koji`` target
+    ``--commit-message``
+        Custom commit message for dist-git
+    ``--sync-only``
+        .. versionadded:: 3.4
+
+        Generate files and sync with dist-git, but do not execute build
+    ``--assume-yes``
+        .. versionadded:: 3.4
+
+        Run build in non-interactive mode answering all questions with 'Yes',
+        useful for automation purposes
+      
+      
 
 Example
     Performing scratch build
@@ -175,8 +196,10 @@ This build engine is using `Buildah <https://buildah.io>`_.
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
 
 Example
     Build image using Buildah
@@ -200,8 +223,10 @@ no special configuration is required.
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
 
 Example
     Build image using Podman

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -439,7 +439,7 @@ def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
     }
 
     builder = create_builder_object(
-        mocker, 'osbs', {}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
+        mocker, 'osbs', {'assume_yes': False}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
     with mocker.patch('cekit.tools.get_brew_url', side_effect=subprocess.CalledProcessError(1, 'command')):
         builder.prepare()
@@ -448,7 +448,7 @@ def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
         builder.before_build()
 
     dist_git_class.assert_called_once_with(os.path.join(
-        str(tmpdir), 'osbs', 'repo'), str(tmpdir), 'repo', 'branch')
+        str(tmpdir), 'osbs', 'repo'), str(tmpdir), 'repo', 'branch', False)
 
     copy_mock.assert_has_calls([
         mocker.call(os.path.join(str(tmpdir), 'image', 'Dockerfile'),

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -83,7 +83,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
     # Test setting user for OSBS
@@ -94,7 +94,7 @@ def _get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
             'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'sync_only': False,
-            'commit_message': None
+            'commit_message': None, 'assume_yes': False
         }
     ),
     # Test setting stage environment for OSBS
@@ -104,7 +104,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'sync_only': False, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
     # Test setting nowait for OSBS
@@ -114,7 +114,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': True,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
     (
@@ -141,7 +141,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'release': False,
-            'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None
+            'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }),
     (
         ['build', 'docker'],


### PR DESCRIPTION
This makes it possible to run the OSBS build in a non-interactive
mode by answering any questions with 'Yes'.

This is helpful when using CEKit in an automated CI/CD environment
to trigger OSBS builds.

Fixes #589