### PR TITLE
Add support for squashing for Buildah and Podman

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run: docker info
       - run: podman version
       - run: podman info
-      - run: pip install tox --user
+      - run: pip install tox zipp==0.5.2 --user
       - run: echo 'export PATH=~/.local/bin:$PATH' >> $BASH_ENV
       - run: cd ~/.local/bin && curl -L https://github.com/openshift/source-to-image/releases/download/v1.1.13/source-to-image-v1.1.13-b54d75d3-linux-amd64.tar.gz | tar xvz
       - run: pyenv local 2.7.12 3.5.2 3.6.5 3.7.0

--- a/cekit/builders/buildah.py
+++ b/cekit/builders/buildah.py
@@ -33,12 +33,14 @@ class BuildahBuilder(Builder):
         if not tags:
             tags = self.generator.get_tags()
 
+        if not self.params.no_squash:
+            cmd.append('--squash')
+
         if self.params.pull:
             cmd.append('--pull-always')
 
         # Custom tags for the container image
-        LOGGER.debug("Building image with tags: '{}'",
-                     "', '".join(tags))
+        LOGGER.debug("Building image with tags: '{}'".format("', '".join(tags)))
 
         for tag in tags:
             cmd.extend(["-t", tag])

--- a/cekit/builders/podman.py
+++ b/cekit/builders/podman.py
@@ -36,6 +36,9 @@ class PodmanBuilder(Builder):
         if self.params.pull:
             cmd.append('--pull-always')
 
+        if not self.params.no_squash:
+            cmd.append('--squash')
+
         # Custom tags for the container image
         LOGGER.debug("Building image with tags: '{}'".format("', '".join(tags)))
 

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -109,9 +109,10 @@ def build_docker(ctx, pull, no_squash, tags):  # pylint: disable=unused-argument
 
 @build.command(name="buildah", short_help="Build using Buildah engine")
 @click.option('--pull', help="Always try to fetch latest base image.", is_flag=True)
+@click.option('--no-squash', help="Do not squash the image after build is done.", is_flag=True)
 @click.option('--tag', 'tags', metavar="TAG", help="Use specified tag to tag the image after build, can be specified multiple times.", multiple=True)
 @click.pass_context
-def build_buildah(ctx, pull, tags):  # pylint: disable=unused-argument
+def build_buildah(ctx, pull, no_squash, tags):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 
@@ -124,9 +125,10 @@ def build_buildah(ctx, pull, tags):  # pylint: disable=unused-argument
 
 @build.command(name="podman", short_help="Build using Podman engine")
 @click.option('--pull', help="Always try to fetch latest base image.", is_flag=True)
+@click.option('--no-squash', help="Do not squash the image after build is done.", is_flag=True)
 @click.option('--tag', 'tags', metavar="TAG", help="Use specified tag to tag the image after build, can be specified multiple times.", multiple=True)
 @click.pass_context
-def build_podman(ctx, pull, tags):  # pylint: disable=unused-argument
+def build_podman(ctx, pull, no_squash, tags):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -567,7 +567,8 @@ def test_docker_squashing_enabled(mocker):
 
 
 def test_docker_squashing_disabled(mocker):
-    builder = DockerBuilder(Map(merge_two_dicts({'target': 'something'}, {'no_squash': True, 'tags': ['foo', 'bar']})))
+    builder = DockerBuilder(Map(merge_two_dicts({'target': 'something'}, {
+                            'no_squash': True, 'tags': ['foo', 'bar']})))
 
     assert builder.params.no_squash == True
 
@@ -615,6 +616,7 @@ def test_buildah_builder_run(mocker):
     check_call.assert_called_once_with([
         '/usr/bin/buildah',
         'build-using-dockerfile',
+        '--squash',
         '-t', 'foo',
         '-t', 'bar',
         'something/image'])
@@ -629,6 +631,7 @@ def test_buildah_builder_run_pull(mocker):
     check_call.assert_called_once_with([
         '/usr/bin/buildah',
         'build-using-dockerfile',
+        '--squash',
         '--pull-always',
         '-t', 'foo',
         '-t', 'bar',
@@ -643,6 +646,7 @@ def test_podman_builder_run(mocker):
 
     check_call.assert_called_once_with(['/usr/bin/podman',
                                         'build',
+                                        '--squash',
                                         '-t', 'foo',
                                         '-t', 'bar',
                                         'something/image'])
@@ -657,6 +661,7 @@ def test_podman_builder_run_pull(mocker):
     check_call.assert_called_once_with(['/usr/bin/podman',
                                         'build',
                                         '--pull-always',
+                                        '--squash',
                                         '-t', 'foo',
                                         '-t', 'bar',
                                         'something/image'])
@@ -683,6 +688,7 @@ def test_podman_builder_run_with_generator(mocker):
 
     check_call.assert_called_once_with(['/usr/bin/podman',
                                         'build',
+                                        '--squash',
                                         '-t', 'foo:1.9',
                                         '-t', 'foo:latest',
                                         'something/image'])
@@ -709,8 +715,35 @@ def test_buildah_builder_run_with_generator(mocker):
 
     check_call.assert_called_once_with(['/usr/bin/buildah',
                                         'build-using-dockerfile',
+                                        '--squash',
                                         '-t', 'foo:1.9',
                                         '-t', 'foo:latest',
+                                        'something/image'])
+
+
+def test_buildah_builder_with_squashing_disabled(mocker):
+    params = {'tags': ['foo', 'bar'], 'no_squash': True}
+    check_call = mocker.patch.object(subprocess, 'check_call')
+    builder = create_builder_object(mocker, 'buildah', params)
+    builder.run()
+
+    check_call.assert_called_once_with(['/usr/bin/buildah',
+                                        'build-using-dockerfile',
+                                        '-t', 'foo',
+                                        '-t', 'bar',
+                                        'something/image'])
+
+
+def test_podman_builder_with_squashing_disabled(mocker):
+    params = {'tags': ['foo', 'bar'], 'no_squash': True}
+    check_call = mocker.patch.object(subprocess, 'check_call')
+    builder = create_builder_object(mocker, 'podman', params)
+    builder.run()
+
+    check_call.assert_called_once_with(['/usr/bin/podman',
+                                        'build',
+                                        '-t', 'foo',
+                                        '-t', 'bar',
                                         'something/image'])
 
 

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -157,7 +157,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.buildah.BuildahBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'tags': ()
+            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'tags': (), 'no_squash': False
         }
     )
 ])


### PR DESCRIPTION
This makes use of the squashing feature of the Buildah and
Podman builder. We squash images by default now.

It is possible to disable squashing by using the: `--no-squash`
switch for both: Podman and Buildah builders.

Additionally the `BUILDAH_LAYERS` environment variable documentation
was adeded for above builders.

Fixes #441
Fixes #597
Fixes #598