### PR TITLE
Add support for specifying koji target in descriptor

### DIFF
--- a/cekit/builder.py
+++ b/cekit/builder.py
@@ -53,7 +53,8 @@ class Builder(Command):
         self.before_generate()
 
         if self.params.validate:
-            LOGGER.info("The --validate parameter was specified, generation will not be performed, exiting")
+            LOGGER.info(
+                "The --validate parameter was specified, generation will not be performed, exiting")
             return
 
         self.generate()
@@ -78,6 +79,11 @@ class Builder(Command):
         self.generator = generator_impl(self.params.descriptor,
                                         self.params.target,
                                         self.params.overrides)
+
+        if self.params.get('koji_target', False):
+            LOGGER.warning("The '--koji-target' switch is deprecated, please use overrides " +
+                           "(http://docs.cekit.io/en/latest/handbook/overrides.html) to adjust the koji " +
+                           "target, '--koji-target' will be removed in version 3.6")
 
         # These should always come last
         if self.params.get('tech_preview', False):

--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -251,8 +251,15 @@ class OSBSBuilder(Builder):
             # Construct the url again, with a hash and removed username and password, if any
             src = "git://{}{}#{}".format(url.hostname, url.path, commit)
 
-            target = "{}-containers-candidate".format(self.dist_git.branch)
+            target = self.generator.image.get('osbs', {}).get('koji_target')
 
+            # If target was not specified in the image descriptor
+            if not target:
+                # Default to computed target based on branch
+                target = "{}-containers-candidate".format(self.dist_git.branch)
+
+            # Check if it was specified on command line
+            # TODO: Remove in 3.6
             if self.params.koji_target:
                 target = self.params.koji_target
 

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -146,6 +146,7 @@ def build_podman(ctx, pull, no_squash, tags):  # pylint: disable=unused-argument
 @click.option('--user', metavar="USER", help="User used to kick the build as.")
 @click.option('--nowait', help="Do not wait for the task to finish.", is_flag=True)
 @click.option('--stage', help="Use stage environmen.", is_flag=True)
+# TODO: Remove in 3.6
 @click.option('--koji-target', metavar="TARGET", help="Override the default Koji target.")
 @click.option('--sync-only', help="Generate files and sync with dist-git, but do not execute build.", is_flag=True)
 @click.option('--commit-message', metavar="MESSAGE", help="Custom dist-git commit message.")

--- a/cekit/descriptor/osbs.py
+++ b/cekit/descriptor/osbs.py
@@ -12,6 +12,7 @@ map:
       name: {type: str}
       branch: {type: str}
   configuration: {type: any}
+  koji_target: {type: str}
   extra_dir: {type: str}
 
 """)
@@ -67,6 +68,14 @@ class Osbs(Descriptor):
     @extra_dir.setter
     def extra_dir(self, value):
         self._descriptor['extra_dir'] = value
+
+    @property
+    def koji_target(self):
+        return self.get('koji_target')
+
+    @koji_target.setter
+    def koji_target(self, value):
+        self._descriptor['koji_target'] = value
 
 
 class Configuration(Descriptor):

--- a/docs/descriptor/includes/image/osbs.rst
+++ b/docs/descriptor/includes/image/osbs.rst
@@ -67,6 +67,30 @@ This key serves as a hint which DistGit repository and its branch we use to push
             name: containers/redhat-openjdk-18
             branch: jb-openjdk-1.8-openshift-rhel-7
 
+OSBS Koji target
+^^^^^^^^^^^^^^^^^^^^^
+
+Key
+    ``koji_target``
+Required
+    No
+
+To execute a build in OSBS the Koji target parameter needs to be provided. By default it is
+constructed based on the branch name (see above), like this:
+
+.. code-block::
+
+    [BRANCH_NAME]-containers-candidate
+
+In most cases this is what is expected, but sometimes you want to change this. An example of such
+situation is when you use a custom, private branch to execute a scratch build. Target can be
+overridden by specifying the ``koji_target`` key.
+
+.. code-block:: yaml
+
+    osbs:
+        koji_target: rhaos-middleware-rhel-7-containers-candidate
+
 OSBS configuration
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/handbook/building/builder-engines.rst
+++ b/docs/handbook/building/builder-engines.rst
@@ -137,6 +137,8 @@ Parameters
     ``--stage``
         Use stage environment
     ``--koji-target``
+        .. deprecated:: 3.5
+
         Overrides the default ``koji`` target
     ``--commit-message``
         Custom commit message for dist-git


### PR DESCRIPTION
Makes it possible to define koji target in the image desciptor.
The --koji-target switch from OSBS builder was marked as deprecated.

Fixes #591