### PR TITLE
Show schema for artifacts in documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
             mkdir -p ./venv
             virtualenv ./venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r ../requirements.txt -r requirements.txt
       - run:
           name: Generate documentation
           command: |

--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -313,19 +313,21 @@ class _PathResource(Resource):
     Documentation: http://docs.cekit.io/en/latest/descriptor/image.html#path-artifacts
     """
 
-    def __init__(self, descriptor, directory):
-        self.schema = {
-            'map': {
-                'name': {'type': 'str'},
-                'target': {'type': 'str'},
-                'description': {'type': 'str'},
-                'path': {'type': 'str', 'required': True},
-                'md5': {'type': 'str'},
-                'sha1': {'type': 'str'},
-                'sha256': {'type': 'str'},
-                'sha512': {'type': 'str'}
-            }
+    SCHEMA = {
+        'map': {
+            'name': {'type': 'str', 'desc': 'Key used to identify the resource'},
+            'target': {'type': 'str', 'desc': 'Target file name for the resource'},
+            'description': {'type': 'str', 'desc': 'Description of the resource'},
+            'path': {'type': 'str', 'required': True, 'desc': 'Relative (suggested) or absolute path to the resource'},
+            'md5': {'type': 'str', 'desc': 'The md5 checksum of the resource'},
+            'sha1': {'type': 'str', 'desc': 'The sha1 checksum of the resource'},
+            'sha256': {'type': 'str', 'desc': 'The sha256 checksum of the resource'},
+            'sha512': {'type': 'str', 'desc': 'The sha512 checksum of the resource'}
         }
+    }
+
+    def __init__(self, descriptor, directory):
+        self.schema = _PathResource.SCHEMA
 
         super(_PathResource, self).__init__(descriptor)
 
@@ -373,19 +375,21 @@ class _UrlResource(Resource):
     Documentation: http://docs.cekit.io/en/latest/descriptor/image.html#url-artifacts
     """
 
-    def __init__(self, descriptor):
-        self.schema = {
-            'map': {
-                'name': {'type': 'str'},
-                'target': {'type': 'str'},
-                'description': {'type': 'str'},
-                'url': {'type': 'str', 'required': True},
-                'md5': {'type': 'str'},
-                'sha1': {'type': 'str'},
-                'sha256': {'type': 'str'},
-                'sha512': {'type': 'str'}
-            }
+    SCHEMA = {
+        'map': {
+            'name': {'type': 'str', 'desc': 'Key used to identify the resource'},
+            'target': {'type': 'str', 'desc': 'Target file name for the resource'},
+            'description': {'type': 'str', 'desc': 'Description of the resource'},
+            'url': {'type': 'str', 'required': True, 'desc': 'URL where the resource can be found'},
+            'md5': {'type': 'str', 'desc': 'The md5 checksum of the resource'},
+            'sha1': {'type': 'str', 'desc': 'The sha1 checksum of the resource'},
+            'sha256': {'type': 'str', 'desc': 'The sha256 checksum of the resource'},
+            'sha512': {'type': 'str', 'desc': 'The sha512 checksum of the resource'}
         }
+    }
+
+    def __init__(self, descriptor):
+        self.schema = _UrlResource.SCHEMA
 
         super(_UrlResource, self).__init__(descriptor)
 
@@ -409,21 +413,23 @@ class _UrlResource(Resource):
 
 class _GitResource(Resource):
 
-    def __init__(self, descriptor):
-        self.schema = {
-            'map': {
-                'name': {'type': 'str'},
-                'target': {'type': 'str'},
-                'description': {'type': 'str'},
-                'git': {
-                    'required': True,
-                    'map': {
-                        'url': {'type': 'str', 'required': True},
-                        'ref': {'type': 'str', 'required': True},
-                    }
+    SCHEMA = {
+        'map': {
+            'name': {'type': 'str', 'desc': 'Key used to identify the resource'},
+            'target': {'type': 'str', 'desc': 'Target file name for the resource'},
+            'description': {'type': 'str', 'desc': 'Description of the resource'},
+            'git': {
+                'required': True,
+                'map': {
+                    'url': {'type': 'str', 'required': True, 'desc': 'URL of the repository'},
+                    'ref': {'type': 'str', 'required': True, 'desc': 'Reference to check out; could be branch, tag, etc'},
                 }
             }
         }
+    }
+
+    def __init__(self, descriptor):
+        self.schema = _GitResource.SCHEMA
 
         super(_GitResource, self).__init__(descriptor)
 
@@ -446,18 +452,20 @@ class _PlainResource(Resource):
     Documentation: http://docs.cekit.io/en/latest/descriptor/image.html#plain-artifacts
     """
 
-    def __init__(self, descriptor):
-        self.schema = {
-            'map': {
-                'name': {'type': 'str', 'required': True},
-                'target': {'type': 'str'},
-                'description': {'type': 'str'},
-                'md5': {'type': 'str', 'required': True},
-                'sha1': {'type': 'str'},
-                'sha256': {'type': 'str'},
-                'sha512': {'type': 'str'}
-            }
+    SCHEMA = {
+        'map': {
+            'name': {'type': 'str', 'required': True, 'desc': 'Key used to identify the resource'},
+            'target': {'type': 'str', 'desc': 'Target file name for the resource'},
+            'description': {'type': 'str', 'desc': 'Description of the resource'},
+            'md5': {'type': 'str', 'required': True, 'desc': 'The md5 checksum of the resource'},
+            'sha1': {'type': 'str', 'desc': 'The sha1 checksum of the resource'},
+            'sha256': {'type': 'str', 'desc': 'The sha256 checksum of the resource'},
+            'sha512': {'type': 'str', 'desc': 'The sha512 checksum of the resource'}
         }
+    }
+
+    def __init__(self, descriptor):
+        self.schema = _PlainResource.SCHEMA
 
         super(_PlainResource, self).__init__(descriptor)
 
@@ -505,16 +513,18 @@ class _ImageContentResource(Resource):
     checksums of such resources.
     """
 
-    def __init__(self, descriptor):
-        self.schema = {
-            'map': {
-                'name': {'type': 'str'},
-                'target': {'type': 'str'},
-                'description': {'type': 'str'},
-                'image': {'type': 'str', 'required': True},
-                'path': {'type': 'str', 'required': True}
-            }
+    SCHEMA = {
+        'map': {
+            'name': {'type': 'str', 'desc': 'Key used to identify the resource'},
+            'target': {'type': 'str', 'desc': 'Target file name for the resource'},
+            'description': {'type': 'str', 'desc': 'Description of the resource'},
+            'image': {'type': 'str', 'required': True, 'desc': 'Name of the image which holds the resource'},
+            'path': {'type': 'str', 'required': True, 'desc': 'Path in the image under which the resource can be found'}
         }
+    }
+
+    def __init__(self, descriptor):
+        self.schema = _ImageContentResource.SCHEMA
 
         super(_ImageContentResource, self).__init__(descriptor)
 

--- a/docs/_ext/schema.py
+++ b/docs/_ext/schema.py
@@ -1,0 +1,54 @@
+import importlib
+import json
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+
+from sphinx.util.docutils import SphinxDirective
+from sphinx.directives.code import container_wrapper
+
+
+class SchemaDirective(SphinxDirective):
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 1
+
+    option_spec = {
+        'name': directives.unchanged
+    }
+
+    def run(self):
+        module, clazz = self.arguments[0].rsplit(".", 1)
+
+        module = importlib.import_module(module)
+        clazz = getattr(module, clazz)
+
+        if not clazz.SCHEMA:
+            return []
+
+        code = nodes.literal_block(text=json.dumps(clazz.SCHEMA, indent=4, sort_keys=True))
+        code['language'] = 'json'
+
+        code = container_wrapper(self, code, "Schema")
+
+        self.add_name(code)
+
+        return [code]
+
+
+def setup(app):
+    app.add_directive('schema', SchemaDirective,
+                      content=0, arguments=(1, 0, 0),
+                      linenos=directives.flag,
+                      language=directives.unchanged,
+                      encoding=directives.encoding)
+
+    # TODO: Replace nodes after the source was changed
+    # app.connect('source-read', process_schema_nodes)
+    # app.connect('doctree-resolved', process_schema_nodes)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath('..'))
+sys.path.append(os.path.abspath("./_ext"))
 
 from cekit import version as cekit_version
 
@@ -16,7 +17,7 @@ def setup(app):
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.graphviz', 'sphinx.ext.autosectionlabel', 'sphinx.ext.todo']
+extensions = ['sphinx.ext.graphviz', 'sphinx.ext.autosectionlabel', 'sphinx.ext.todo', 'schema']
 # http://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html#confval-autosectionlabel_prefix_document
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 4

--- a/docs/descriptor/includes/artifacts.rst
+++ b/docs/descriptor/includes/artifacts.rst
@@ -4,7 +4,7 @@ Artifacts
 It's common for images to require external artifacts like jar files, installers, etc.
 In most cases you will want to add some files into the image and use them during image build process.
 
-Artifacts section is meant exactly for this. CEKit will *automatically*
+Artifacts section is meant exactly for this. CEKit will try to *automatically*
 fetch any artifacts specified in this section.
 
 If for some reason automatic fetching of artifacts is not an option for you,
@@ -16,8 +16,8 @@ Artifact features
 ^^^^^^^^^^^^^^^^^^^^
 
 Checksums
-    All artifacts will be checked for consistency by computing checksum of
-    the downloaded file and comparing it with the desired value. Currently supported algorithms
+    Almost all artifacts will be checked for consistency by computing checksum of
+    the fetched file and comparing it with the desired value. Currently supported algorithms
     are: ``md5``, ``sha1``, ``sha256`` and ``sha512``.
 
     You can define multiple checksums for a single artifact. All specified checksums will
@@ -80,12 +80,6 @@ Common artifact keys
 
         Target file name: ``jboss-eap-6.4.0.zip``.
 
-``md5``, ``sha1``, ``sha256``, ``sha512``
-    Checksum algorithms. These keys can be provided to make sure the fetched artifact
-    is valid.
-
-    See section above about checksums.
-
 ``description``
    Describes the artifact. This is an optional key that can be used to add more information
    about the artifact.
@@ -117,40 +111,59 @@ CEKit supports following artifact types:
 Plain artifacts
 ******************
 
-This is an abstract way of defining artifacts. The only required keys are ``name`` and checksum.
+This is an abstract way of defining artifacts. The only required keys are ``name`` and the ``md5`` checksum.
 This type of artifacts is used to define artifacts that are not available publicly and instead
 provided by some (internal) systems.
 
-This approach relies on :doc:`/handbook//caching` to provide the artifact.
+.. schema:: cekit.descriptor.resource._PlainResource
+    :name: plain-artifact-schema
 
-.. code-block:: yaml 
+.. code-block:: yaml
+    :name: plain-artifact-examples
+    :caption: Examples
 
     artifacts:
-        - name: jolokia-1.3.6-bin.tar.gz
+        - name: jolokia
           md5: 75e5b5ba0b804cd9def9f20a70af649f
-          target: jolokia.jar
+          target: jolokia.tar.gz
+
+As you can see, the definition does not define from where the artifact should be fetched.
+This approach relies on :doc:`/handbook/caching` to provide the artifact.
 
 .. note::
 
    See :doc:`/handbook/redhat` for description how plain artifacts are used in the
    Red Hat environment.
 
-          
 URL artifacts
 ******************
 
 This is the simplest way of defining artifacts. You need to provide the ``url`` key which is the URL from where the
 artifact should be fetched from.
 
+.. schema:: cekit.descriptor.resource._UrlResource
+    :name: url-artifact-schema
+
 .. tip::
-    You should always specify checksums to make sure the downloaded artifact is correct.
+    You should always specify at least one checksum to make sure the downloaded artifact is correct.
 
 .. code-block:: yaml
+    :name: url-artifact-examples
+    :caption: Examples
 
     artifacts:
-        - name: jolokia-1.3.6-bin.tar.gz
-          url: https://github.com/rhuss/jolokia/releases/download/v1.3.6/jolokia-1.3.6-bin.tar.gz
-          md5: 75e5b5ba0b804cd9def9f20a70af649f
+        - name: "jolokia"
+          url: "https://github.com/rhuss/jolokia/releases/download/v1.3.6/jolokia-1.3.6-bin.tar.gz"
+          # The md5 checksum of the artifact
+          md5: "75e5b5ba0b804cd9def9f20a70af649f"
+
+        - name: "jolokia"
+          url: "https://github.com/rhuss/jolokia/releases/download/v1.3.6/jolokia-1.3.6-bin.tar.gz"
+          # Free text description of the artifact
+          description: "Library required to access server data via JMX"
+          md5: "75e5b5ba0b804cd9def9f20a70af649f"
+          # Final name of the downloaded artifact
+          target: "jolokia.tar.gz"
 
 Path artifacts
 ******************
@@ -158,7 +171,15 @@ Path artifacts
 This way of defining artifacts is mostly used in development :doc:`overrides </handbook/overrides>`
 and enables you to inject artifacts from a local filesystem.
 
+.. schema:: cekit.descriptor.resource._PathResource
+    :name: path-artifact-schema
+
+.. tip::
+    You should always specify at least one checksum to make sure the artifact is correct.
+
 .. code-block:: yaml
+    :name: path-artifact-examples
+    :caption: Examples
 
     artifacts:
         - name: jolokia-1.3.6-bin.tar.gz
@@ -177,15 +198,24 @@ and enables you to inject artifacts from a local filesystem.
 Image source artifacts
 ************************
 
-Image source artifacts are used in multi-stage builds. With image source artifacts you can define
-files built in previous stages of the multi-stage builds.
+Image source artifacts are used in :doc:`multi-stage builds </handbook/multi-stage>`.
+With image source artifacts you can define files built in previous stages of the
+multi-stage builds.
 
-.. code-block:: yaml
-
-    artifacts:
-        - name: application
-          image: builder
-          path: /path/to/application/inside/the/builder/image.jar
+.. schema:: cekit.descriptor.resource._ImageContentResource
+    :name: image-source-artifact-schema
 
 .. note::
    Please note that image source artifacts do not allow for defining checksums due to the nature of this type of artifact.
+
+.. code-block:: yaml
+    :name: image-source-artifact-examples
+    :caption: Examples
+
+    artifacts:
+        - name: application
+          # Name of the image (stage) from where we will fetch the artifact
+          image: builder
+          # Path to the artifact within the image
+          path: /path/to/application/inside/the/builder/image.jar
+


### PR DESCRIPTION
This is a PoC where the schema of particular element is shown
in the documentation. This supports only artifacts for now,
but it could be possibly extended for other elements
in the future.

Fixes #607