### PR TITLE
Release 3.2.1

### DIFF
--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -113,7 +113,8 @@ class OSBSBuilder(Builder):
         self.dist_git = DistGit(self.dist_git_dir,
                                 self.target,
                                 repository,
-                                branch)
+                                branch,
+                                self.params.assume_yes)
 
         self.dist_git.prepare(self.params.stage, self.params.user)
         self.dist_git.clean()
@@ -267,7 +268,7 @@ class OSBSBuilder(Builder):
 
             LOGGER.info("About to execute '%s'." % ' '.join(cmd))
 
-            if tools.decision("Do you want to build the image in OSBS?"):
+            if self.params.assume_yes or tools.decision("Do you want to build the image in OSBS?"):
                 build_type = "scratch" if scratch else "release"
                 LOGGER.info("Executing %s container build in OSBS..." % build_type)
 

--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -85,10 +85,11 @@ class OSBSBuilder(Builder):
 
         super(OSBSBuilder, self).before_run()
 
-        self.prepare_dist_git()
-        self.copy_to_dist_git()
+        self._prepare_dist_git()
+        self._copy_to_dist_git()
+        self._sync_with_dist_git()
 
-    def prepare_dist_git(self):
+    def _prepare_dist_git(self):
         repository_key = self.generator.image.get('osbs', {}).get('repository', {})
 
         repository = repository_key.get('name')
@@ -129,9 +130,20 @@ class OSBSBuilder(Builder):
             self._rhpkg_set_url_repos = [x['url']['repository']
                                          for x in self.generator.image['packages']['set_url']]
 
-    def copy_to_dist_git(self):
+    def _copy_to_dist_git(self):
         LOGGER.debug("Copying files to dist-git '{}' directory".format(self.dist_git_dir))
         copy_recursively(os.path.join(self.target, 'image'), self.dist_git_dir)
+
+    def _sync_with_dist_git(self):
+        with Chdir(self.dist_git_dir):
+            self.dist_git.add(self.artifacts)
+            self.update_lookaside_cache()
+
+            if self.dist_git.stage_modified():
+                self.dist_git.commit(self.params.commit_message)
+                self.dist_git.push()
+            else:
+                LOGGER.info("No changes made to the code, committing skipped")
 
     def _merge_container_yaml(self, src, dest):
         # FIXME - this is temporary needs to be refactored to proper merging
@@ -216,6 +228,10 @@ class OSBSBuilder(Builder):
         LOGGER.info("Update finished.")
 
     def run(self):
+        if self.params.sync_only:
+            LOGGER.info("The --sync-only parameter was specified, build will not be executed, exiting")
+            return
+
         cmd = [self._koji]
 
         if self.params.user:
@@ -224,15 +240,6 @@ class OSBSBuilder(Builder):
         cmd += ['call', '--python', 'buildContainer', '--kwargs']
 
         with Chdir(self.dist_git_dir):
-            self.dist_git.add(self.artifacts)
-            self.update_lookaside_cache()
-
-            if self.dist_git.stage_modified():
-                self.dist_git.commit(self.params.commit_message)
-                self.dist_git.push()
-            else:
-                LOGGER.info("No changes made to the code, committing skipped")
-
             # Get the url of the repository
             url = subprocess.check_output(
                 ["git", "config", "--get", "remote.origin.url"]).strip().decode("utf8")

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -144,9 +144,10 @@ def build_podman(ctx, pull, tags):  # pylint: disable=unused-argument
 @click.option('--nowait', help="Do not wait for the task to finish.", is_flag=True)
 @click.option('--stage', help="Use stage environmen.", is_flag=True)
 @click.option('--koji-target', metavar="TARGET", help="Override the default Koji target.")
+@click.option('--sync-only', help="Generate files and sync with dist-git, but do not execute build.", is_flag=True)
 @click.option('--commit-message', metavar="MESSAGE", help="Custom dist-git commit message.")
 @click.pass_context
-def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, commit_message):  # pylint: disable=unused-argument
+def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -146,8 +146,9 @@ def build_podman(ctx, pull, tags):  # pylint: disable=unused-argument
 @click.option('--koji-target', metavar="TARGET", help="Override the default Koji target.")
 @click.option('--sync-only', help="Generate files and sync with dist-git, but do not execute build.", is_flag=True)
 @click.option('--commit-message', metavar="MESSAGE", help="Custom dist-git commit message.")
+@click.option('--assume-yes', '-y', help="Execute build in non-interactive mode.", is_flag=True)
 @click.pass_context
-def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message):  # pylint: disable=unused-argument
+def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message, assume_yes):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/cekit/version.py
+++ b/cekit/version.py
@@ -1,2 +1,2 @@
-version = "3.2.0"
+version = "3.2.1"
 schema_version = 2

--- a/docs/handbook/building/builder-engines.rst
+++ b/docs/handbook/building/builder-engines.rst
@@ -19,9 +19,12 @@ This builder uses Docker daemon as the build engine. Interaction with Docker dae
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
-    * ``--no-squash`` -- do not squash the image after build is done.
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
+    ``--no-squash``
+        Do not squash the image after build is done.
 
 Example
     Building Docker image
@@ -74,14 +77,26 @@ it performs **scratch build**. If you need a proper build you need to specify ``
 Input format
     Dockerfile
 Parameters
-    * ``--release`` -- perform an OSBS release build
-    * ``--tech-preview`` -- updates image descriptor ``name`` key to contain ``--tech-preview`` suffix in family part of the image name
-    * ``--user`` -- alternative user passed to build task
-    * ``--nowait`` -- do not wait for the task to finish
-    * ``--stage`` -- use stage environment
-    * ``--koji-target`` -- overrides the default ``koji`` target
-    * ``--commit-message`` -- custom commit message for dist-git
-    * ``--sync-only`` -- generate files and sync with dist-git, but do not execute build
+    ``--release``
+        Perform an OSBS release build
+    ``--tech-preview``
+        Build tech preview image, see
+        :ref:`below for more information <handbook/building/builder-engines:Tech preview images>`
+    ``--user``
+        Alternative user passed to build task
+    ``--nowait``
+        Do not wait for the task to finish
+    ``--stage``
+        Use stage environment
+    ``--koji-target``
+        Overrides the default ``koji`` target
+    ``--commit-message``
+        Custom commit message for dist-git
+    ``--sync-only``
+        Generate files and sync with dist-git, but do not execute build
+    ``--assume-yes``
+        Run build in non-interactive mode answering all questions with 'Yes',
+        useful for automation purposes
 
 Example
     Performing scratch build
@@ -107,8 +122,10 @@ This build engine is using `Buildah <https://buildah.io>`_.
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
 
 Example
     Build image using Buildah
@@ -132,8 +149,10 @@ no special configuration is required.
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
 
 Example
     Build image using Podman

--- a/docs/handbook/building/builder-engines.rst
+++ b/docs/handbook/building/builder-engines.rst
@@ -80,7 +80,8 @@ Parameters
     * ``--nowait`` -- do not wait for the task to finish
     * ``--stage`` -- use stage environment
     * ``--koji-target`` -- overrides the default ``koji`` target
-    * ``--commit-msg`` -- custom commit message for dist-git
+    * ``--commit-message`` -- custom commit message for dist-git
+    * ``--sync-only`` -- generate files and sync with dist-git, but do not execute build
 
 Example
     Performing scratch build

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -412,6 +412,7 @@ def test_osbs_wait_for_osbs_task_failed(mocker):
 def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
     os.makedirs(os.path.join(str(tmpdir), 'image'))
 
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.tools.DependencyHandler.handle')
     mocker.patch('cekit.descriptor.resource.Resource.copy')
     copy_mock = mocker.patch('cekit.builders.osbs.shutil.copy2')
@@ -481,8 +482,8 @@ def test_osbs_dist_git_sync_called(mocker, tmpdir):
     builder = create_builder_object(
         mocker, 'osbs', {}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
-    prepare_dist_git = mocker.patch.object(builder, 'prepare_dist_git')
-    copy_to_dist_git = mocker.patch.object(builder, 'copy_to_dist_git')
+    prepare_dist_git = mocker.patch.object(builder, '_prepare_dist_git')
+    copy_to_dist_git = mocker.patch.object(builder, '_copy_to_dist_git')
     run = mocker.patch.object(builder, 'run')
 
     builder.execute()
@@ -512,14 +513,16 @@ def test_osbs_dist_git_sync_NOT_called_when_dry_run_set(mocker, tmpdir):
     builder = create_builder_object(
         mocker, 'osbs', {'dry_run': True}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
-    prepare_dist_git = mocker.patch.object(builder, 'prepare_dist_git')
-    copy_to_dist_git = mocker.patch.object(builder, 'copy_to_dist_git')
+    prepare_dist_git = mocker.patch.object(builder, '_prepare_dist_git')
+    copy_to_dist_git = mocker.patch.object(builder, '_copy_to_dist_git')
+    sync_with_dist_git = mocker.patch.object(builder, '_sync_with_dist_git')
     run = mocker.patch.object(builder, 'run')
 
     builder.execute()
 
     prepare_dist_git.assert_not_called()
     copy_to_dist_git.assert_not_called()
+    sync_with_dist_git.assert_not_called()
     run.assert_not_called()
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -441,14 +441,14 @@ def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
     }
 
     builder = create_builder_object(
-        mocker, 'osbs', {}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
+        mocker, 'osbs', {'assume_yes': False}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
     with mocker.patch('cekit.tools.get_brew_url', side_effect=subprocess.CalledProcessError(1, 'command')):
         builder.prepare()
         builder.before_run()
 
     dist_git_class.assert_called_once_with(os.path.join(
-        str(tmpdir), 'osbs', 'repo'), str(tmpdir), 'repo', 'branch')
+        str(tmpdir), 'osbs', 'repo'), str(tmpdir), 'repo', 'branch', False)
 
     copy_mock.assert_has_calls([
         mocker.call(os.path.join(str(tmpdir), 'image', 'Dockerfile'),

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -88,8 +88,9 @@ def test_dockerfile_rendering(tmpdir, mocker, name, desc_part, exp_regex):
                          ],
                          ids=print_test_name)
 def test_dockerfile_rendering_tech_preview(tmpdir, mocker, desc_part, exp_regex):
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
 
@@ -102,7 +103,7 @@ def test_dockerfile_docker_odcs_pulp(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
     mocker.patch('cekit.generator.docker.DockerGenerator.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'content_sets': {
@@ -119,8 +120,9 @@ def test_dockerfile_docker_odcs_rpm(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
 
     target = str(tmpdir.mkdir('target'))
@@ -156,8 +158,9 @@ def test_dockerfile_osbs_odcs_pulp(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     config.cfg['common'] = {'redhat': True}
 
@@ -182,8 +185,9 @@ def test_dockerfile_osbs_odcs_pulp_no_redhat(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     config.cfg['common'] = {'redhat': False}
 
@@ -207,8 +211,9 @@ def test_dockerfile_osbs_id_redhat_false(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'repositories': [{'name': 'foo',
@@ -227,8 +232,9 @@ def test_dockerfile_osbs_url_only(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'repositories': [{'name': 'foo',

--- a/tests/test_integ_builder_osbs.py
+++ b/tests/test_integ_builder_osbs.py
@@ -68,7 +68,6 @@ def run_osbs(descriptor, image_dir, mocker, return_code=0, build_command=None):
     mocker.patch('cekit.builders.osbs.OSBSBuilder._wait_for_osbs_task')
     mocker.patch('cekit.builders.osbs.DistGit.clean')
     mocker.patch('cekit.builders.osbs.DistGit.prepare')
-    mocker.patch('cekit.tools.decision', return_value=True)
 
     mocker_check_output = mocker.patch.object(subprocess, 'check_output', side_effect=[
         b"true",  # git rev-parse --is-inside-work-tree
@@ -96,6 +95,35 @@ def run_osbs(descriptor, image_dir, mocker, return_code=0, build_command=None):
                      return_code=return_code)
 
 
+def test_osbs_builder_with_asume_yes(tmpdir, mocker, caplog):
+    caplog.set_level(logging.DEBUG, logger="cekit")
+
+    # Specifically set the decision result to False, to fail any build
+    # that depends on the decision. But in case the --assume-yes switch is used
+    # we should not get to this point at all. If we get, the test should fail.
+    mock_decision = mocker.patch('cekit.tools.decision', return_value=False)
+    mock_check_call = mocker.patch.object(subprocess, 'check_call')
+    mocker.patch.object(subprocess, 'call', return_value=1)
+
+    source_dir = tmpdir.mkdir('source')
+    source_dir.mkdir('osbs').mkdir('repo')
+
+    run_osbs(image_descriptor.copy(), str(source_dir), mocker, 0, ['build', 'osbs', '--assume-yes'])
+
+    mock_decision.assert_not_called()
+
+    mock_check_call.assert_has_calls(
+        [
+            mocker.call(['git', 'add', '--all', 'Dockerfile']),
+            mocker.call(['git', 'commit', '-q', '-m',
+                         'Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb']),
+            mocker.call(['git', 'push', '-q', 'origin', 'branch'])
+        ])
+
+    assert "Commiting with message: 'Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb'" in caplog.text
+    assert "Image was built successfully in OSBS!" in caplog.text
+
+
 def test_osbs_builder_with_push_with_sync_only(tmpdir, mocker, caplog):
     """
     Should sync with dist-git repository without kicking the build
@@ -106,6 +134,7 @@ def test_osbs_builder_with_push_with_sync_only(tmpdir, mocker, caplog):
     source_dir = tmpdir.mkdir('source')
     repo_dir = source_dir.mkdir('osbs').mkdir('repo')
 
+    mocker.patch('cekit.tools.decision', return_value=True)
     mocker.patch.object(subprocess, 'call', return_value=1)
 
     mock_check_call = mocker.patch.object(subprocess, 'check_call')
@@ -136,6 +165,7 @@ def test_osbs_builder_kick_build_without_push(tmpdir, mocker, caplog):
 
     caplog.set_level(logging.DEBUG, logger="cekit")
 
+    mocker.patch('cekit.tools.decision', return_value=True)
     mocker.patch.object(subprocess, 'call', return_value=0)
 
     source_dir = tmpdir.mkdir('source')
@@ -169,6 +199,7 @@ def test_osbs_builder_kick_build_with_push(tmpdir, mocker, caplog):
     source_dir = tmpdir.mkdir('source')
     repo_dir = source_dir.mkdir('osbs').mkdir('repo')
 
+    mocker.patch('cekit.tools.decision', return_value=True)
     mocker.patch.object(subprocess, 'call', return_value=1)
 
     mock_check_call = mocker.patch.object(subprocess, 'check_call')
@@ -198,6 +229,8 @@ def test_osbs_builder_add_help_file(tmpdir, mocker, caplog):
     """
 
     caplog.set_level(logging.DEBUG, logger="cekit")
+
+    mocker.patch('cekit.tools.decision', return_value=True)
 
     source_dir = tmpdir.mkdir('source')
     repo_dir = source_dir.mkdir('osbs').mkdir('repo')
@@ -231,6 +264,8 @@ def test_osbs_builder_add_extra_files(tmpdir, mocker, caplog):
     """
 
     caplog.set_level(logging.DEBUG, logger="cekit")
+
+    mocker.patch('cekit.tools.decision', return_value=True)
 
     source_dir = tmpdir.mkdir('source')
     repo_dir = source_dir.mkdir('osbs').mkdir('repo')
@@ -277,6 +312,8 @@ def test_osbs_builder_add_extra_files_from_custom_dir(tmpdir, mocker, caplog):
     """
 
     caplog.set_level(logging.DEBUG, logger="cekit")
+
+    mocker.patch('cekit.tools.decision', return_value=True)
 
     source_dir = tmpdir.mkdir('source')
     repo_dir = source_dir.mkdir('osbs').mkdir('repo')
@@ -348,6 +385,7 @@ def test_osbs_builder_extra_default(tmpdir, mocker, caplog):
 
 
 def test_osbs_builder_add_files_to_dist_git_without_dotgit_directory(tmpdir, mocker, caplog):
+    mocker.patch('cekit.tools.decision', return_value=True)
     mocker.patch.object(subprocess, 'call')
     mock_check_call = mocker.patch.object(subprocess, 'check_call')
     #mock_check_output = mocker.patch.object(subprocess, 'check_output')
@@ -374,6 +412,6 @@ def test_osbs_builder_add_files_to_dist_git_without_dotgit_directory(tmpdir, moc
         mocker.call(['git', 'add', '--all', 'Dockerfile'])
     ]
 
-    assert len(mock_check_call.mock_calls) == len(calls)
     mock_check_call.assert_has_calls(calls, any_order=True)
+    assert len(mock_check_call.mock_calls) == len(calls)
     assert "Skipping '.git' directory" in caplog.text

--- a/tests/test_integ_builder_osbs.py
+++ b/tests/test_integ_builder_osbs.py
@@ -59,7 +59,10 @@ def run_cekit(cwd,
         return result
 
 
-def run_osbs(descriptor, image_dir, mocker, return_code=0):
+def run_osbs(descriptor, image_dir, mocker, return_code=0, build_command=None):
+    if build_command is None:
+        build_command = ['build', 'osbs']
+
     # We are mocking it, so do not require it at test time
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies', return_value={})
     mocker.patch('cekit.builders.osbs.OSBSBuilder._wait_for_osbs_task')
@@ -89,10 +92,40 @@ def run_osbs(descriptor, image_dir, mocker, return_code=0):
 
     return run_cekit(image_dir, ['-v',
                                  '--work-dir', image_dir,
-                                 '--config', 'config',
-                                 'build',
-                                 'osbs'],
+                                 '--config', 'config'] + build_command,
                      return_code=return_code)
+
+
+def test_osbs_builder_with_push_with_sync_only(tmpdir, mocker, caplog):
+    """
+    Should sync with dist-git repository without kicking the build
+    """
+
+    caplog.set_level(logging.DEBUG, logger="cekit")
+
+    source_dir = tmpdir.mkdir('source')
+    repo_dir = source_dir.mkdir('osbs').mkdir('repo')
+
+    mocker.patch.object(subprocess, 'call', return_value=1)
+
+    mock_check_call = mocker.patch.object(subprocess, 'check_call')
+
+    descriptor = image_descriptor.copy()
+
+    run_osbs(descriptor, str(source_dir), mocker, 0, ['build', 'osbs', '--sync-only'])
+
+    assert os.path.exists(str(repo_dir.join('Dockerfile'))) is True
+
+    mock_check_call.assert_has_calls(
+        [
+            mocker.call(['git', 'add', '--all', 'Dockerfile']),
+            mocker.call(['git', 'commit', '-q', '-m',
+                         'Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb']),
+            mocker.call(['git', 'push', '-q', 'origin', 'branch'])
+        ])
+
+    assert "Commiting with message: 'Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb'" in caplog.text
+    assert "The --sync-only parameter was specified, build will not be executed, exiting" in caplog.text
 
 
 def test_osbs_builder_kick_build_without_push(tmpdir, mocker, caplog):

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -86,7 +86,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False
+            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False, 'assume_yes': False
         }
     ),
     # Test setting user for OSBS
@@ -95,7 +95,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False
+            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False, 'assume_yes': False
         }
     ),
     # Test setting stage environment for OSBS
@@ -104,7 +104,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None, 'sync_only': False
+            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None, 'sync_only': False, 'assume_yes': False
         }
     ),
     # Test setting nowait for OSBS
@@ -113,7 +113,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': True, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False
+            'dry_run': False, 'overrides': (), 'nowait': True, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False, 'assume_yes': False
         }
     ),
     (
@@ -139,7 +139,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'release': False, 'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False
+            'dry_run': False, 'overrides': (), 'release': False, 'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False, 'assume_yes': False
         }),
     (
         ['build', 'docker'],

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -86,7 +86,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
+            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False
         }
     ),
     # Test setting user for OSBS
@@ -95,7 +95,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'commit_message': None
+            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False
         }
     ),
     # Test setting stage environment for OSBS
@@ -104,7 +104,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None
+            'dry_run': False, 'overrides': (), 'nowait': False, 'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None, 'sync_only': False
         }
     ),
     # Test setting nowait for OSBS
@@ -113,7 +113,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'nowait': True, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
+            'dry_run': False, 'overrides': (), 'nowait': True, 'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False
         }
     ),
     (
@@ -139,7 +139,7 @@ def get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         None,
         {
-            'dry_run': False, 'overrides': (), 'release': False, 'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None
+            'dry_run': False, 'overrides': (), 'release': False, 'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None, 'sync_only': False
         }),
     (
         ['build', 'docker'],


### PR DESCRIPTION
This is a one-off release to backport two features into the 3.2.x codebase:

1. Support for `--assume-yes` OSBS builder switch
1. Support for `--sync-only` OSBS builder switch