### PR TITLE
Release 3.3.2

### DIFF
--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -113,7 +113,8 @@ class OSBSBuilder(Builder):
         self.dist_git = DistGit(self.dist_git_dir,
                                 self.target,
                                 repository,
-                                branch)
+                                branch,
+                                self.params.assume_yes)
 
         self.dist_git.prepare(self.params.stage, self.params.user)
         self.dist_git.clean()
@@ -267,7 +268,7 @@ class OSBSBuilder(Builder):
 
             LOGGER.info("About to execute '{}'.".format(' '.join(cmd)))
 
-            if tools.decision("Do you want to build the image in OSBS?"):
+            if self.params.assume_yes or tools.decision("Do you want to build the image in OSBS?"):
                 build_type = "scratch" if scratch else "release"
                 LOGGER.info("Executing {} container build in OSBS...".format(build_type))
 

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -147,8 +147,9 @@ def build_podman(ctx, pull, tags):  # pylint: disable=unused-argument
 @click.option('--koji-target', metavar="TARGET", help="Override the default Koji target.")
 @click.option('--sync-only', help="Generate files and sync with dist-git, but do not execute build.", is_flag=True)
 @click.option('--commit-message', metavar="MESSAGE", help="Custom dist-git commit message.")
+@click.option('--assume-yes', '-y', help="Execute build in non-interactive mode.", is_flag=True)
 @click.pass_context
-def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message):  # pylint: disable=unused-argument
+def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message, assume_yes):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -145,9 +145,10 @@ def build_podman(ctx, pull, tags):  # pylint: disable=unused-argument
 @click.option('--nowait', help="Do not wait for the task to finish.", is_flag=True)
 @click.option('--stage', help="Use stage environmen.", is_flag=True)
 @click.option('--koji-target', metavar="TARGET", help="Override the default Koji target.")
+@click.option('--sync-only', help="Generate files and sync with dist-git, but do not execute build.", is_flag=True)
 @click.option('--commit-message', metavar="MESSAGE", help="Custom dist-git commit message.")
 @click.pass_context
-def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, commit_message):  # pylint: disable=unused-argument
+def build_osbs(ctx, release, tech_preview, user, nowait, stage, koji_target, sync_only, commit_message):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/cekit/version.py
+++ b/cekit/version.py
@@ -1,2 +1,2 @@
-version = "3.3.1"
+version = "3.3.2"
 schema_version = 2

--- a/docs/handbook/building/builder-engines.rst
+++ b/docs/handbook/building/builder-engines.rst
@@ -123,6 +123,7 @@ Parameters
     * ``--stage`` -- use stage environment
     * ``--koji-target`` -- overrides the default ``koji`` target
     * ``--commit-message`` -- custom commit message for dist-git
+    * ``--sync-only`` -- generate files and sync with dist-git, but do not execute build
 
 Example
     Performing scratch build

--- a/docs/handbook/building/builder-engines.rst
+++ b/docs/handbook/building/builder-engines.rst
@@ -19,9 +19,12 @@ This builder uses Docker daemon as the build engine. Interaction with Docker dae
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
-    * ``--no-squash`` -- do not squash the image after build is done.
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
+    ``--no-squash``
+        Do not squash the image after build is done.
 
 Example
     Building Docker image
@@ -116,14 +119,26 @@ it performs **scratch build**. If you need a proper build you need to specify ``
 Input format
     Dockerfile
 Parameters
-    * ``--release`` -- perform an OSBS release build
-    * ``--tech-preview`` -- build tech preview image, see :ref:`below for more information <handbook/building/builder-engines:Tech preview images>`
-    * ``--user`` -- alternative user passed to build task
-    * ``--nowait`` -- do not wait for the task to finish
-    * ``--stage`` -- use stage environment
-    * ``--koji-target`` -- overrides the default ``koji`` target
-    * ``--commit-message`` -- custom commit message for dist-git
-    * ``--sync-only`` -- generate files and sync with dist-git, but do not execute build
+    ``--release``
+        Perform an OSBS release build
+    ``--tech-preview``
+        Build tech preview image, see
+        :ref:`below for more information <handbook/building/builder-engines:Tech preview images>`
+    ``--user``
+        Alternative user passed to build task
+    ``--nowait``
+        Do not wait for the task to finish
+    ``--stage``
+        Use stage environment
+    ``--koji-target``
+        Overrides the default ``koji`` target
+    ``--commit-message``
+        Custom commit message for dist-git
+    ``--sync-only``
+        Generate files and sync with dist-git, but do not execute build
+    ``--assume-yes``
+        Run build in non-interactive mode answering all questions with 'Yes',
+        useful for automation purposes
 
 Example
     Performing scratch build
@@ -175,8 +190,10 @@ This build engine is using `Buildah <https://buildah.io>`_.
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
 
 Example
     Build image using Buildah
@@ -200,8 +217,10 @@ no special configuration is required.
 Input format
     Dockerfile
 Parameters
-    * ``--pull`` -- ask a builder engine to check and fetch latest base image
-    * ``--tag`` -- an image tag used to build image (can be specified multiple times)
+    ``--pull``
+        Ask a builder engine to check and fetch latest base image
+    ``--tag``
+        An image tag used to build image (can be specified multiple times)
 
 Example
     Build image using Podman

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -410,6 +410,7 @@ def test_osbs_wait_for_osbs_task_failed(mocker):
 def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
     os.makedirs(os.path.join(str(tmpdir), 'image'))
 
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.tools.DependencyHandler.handle')
     mocker.patch('cekit.descriptor.resource.Resource.copy')
     copy_mock = mocker.patch('cekit.builders.osbs.shutil.copy2')
@@ -481,8 +482,8 @@ def test_osbs_dist_git_sync_called(mocker, tmpdir):
     builder = create_builder_object(
         mocker, 'osbs', {}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
-    prepare_dist_git = mocker.patch.object(builder, 'prepare_dist_git')
-    copy_to_dist_git = mocker.patch.object(builder, 'copy_to_dist_git')
+    prepare_dist_git = mocker.patch.object(builder, '_prepare_dist_git')
+    copy_to_dist_git = mocker.patch.object(builder, '_copy_to_dist_git')
     run = mocker.patch.object(builder, 'run')
 
     builder.execute()
@@ -512,14 +513,16 @@ def test_osbs_dist_git_sync_NOT_called_when_dry_run_set(mocker, tmpdir):
     builder = create_builder_object(
         mocker, 'osbs', {'dry_run': True}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
-    prepare_dist_git = mocker.patch.object(builder, 'prepare_dist_git')
-    copy_to_dist_git = mocker.patch.object(builder, 'copy_to_dist_git')
+    prepare_dist_git = mocker.patch.object(builder, '_prepare_dist_git')
+    copy_to_dist_git = mocker.patch.object(builder, '_copy_to_dist_git')
+    sync_with_dist_git = mocker.patch.object(builder, '_sync_with_dist_git')
     run = mocker.patch.object(builder, 'run')
 
     builder.execute()
 
     prepare_dist_git.assert_not_called()
     copy_to_dist_git.assert_not_called()
+    sync_with_dist_git.assert_not_called()
     run.assert_not_called()
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -439,7 +439,7 @@ def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
     }
 
     builder = create_builder_object(
-        mocker, 'osbs', {}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
+        mocker, 'osbs', {'assume_yes': False}, {'descriptor': yaml.dump(image_descriptor), 'target': str(tmpdir)})
 
     with mocker.patch('cekit.tools.get_brew_url', side_effect=subprocess.CalledProcessError(1, 'command')):
         builder.prepare()
@@ -448,7 +448,7 @@ def test_osbs_copy_artifacts_to_dist_git(mocker, tmpdir, artifact, src, target):
         builder.before_build()
 
     dist_git_class.assert_called_once_with(os.path.join(
-        str(tmpdir), 'osbs', 'repo'), str(tmpdir), 'repo', 'branch')
+        str(tmpdir), 'osbs', 'repo'), str(tmpdir), 'repo', 'branch', False)
 
     copy_mock.assert_has_calls([
         mocker.call(os.path.join(str(tmpdir), 'image', 'Dockerfile'),

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -88,8 +88,9 @@ def test_dockerfile_rendering(tmpdir, mocker, name, desc_part, exp_regex):
                          ],
                          ids=print_test_name)
 def test_dockerfile_rendering_tech_preview(tmpdir, mocker, desc_part, exp_regex):
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
 
@@ -102,7 +103,7 @@ def test_dockerfile_docker_odcs_pulp(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
     mocker.patch('cekit.generator.docker.DockerGenerator.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'content_sets': {
@@ -119,8 +120,9 @@ def test_dockerfile_docker_odcs_rpm(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
 
     target = str(tmpdir.mkdir('target'))
@@ -156,8 +158,9 @@ def test_dockerfile_osbs_odcs_pulp(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     config.cfg['common'] = {'redhat': True}
 
@@ -182,8 +185,9 @@ def test_dockerfile_osbs_odcs_pulp_no_redhat(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     config.cfg['common'] = {'redhat': False}
 
@@ -207,8 +211,9 @@ def test_dockerfile_osbs_id_redhat_false(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'repositories': [{'name': 'foo',
@@ -227,8 +232,9 @@ def test_dockerfile_osbs_url_only(tmpdir, mocker):
     mocker.patch('odcs.client.odcs.ODCS.wait_for_compose', return_value={
                  'state': 2, 'result_repofile': 'url'})
     mocker.patch.object(Repository, 'fetch')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.prepare_dist_git')
-    mocker.patch('cekit.builders.osbs.OSBSBuilder.copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._prepare_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._copy_to_dist_git')
+    mocker.patch('cekit.builders.osbs.OSBSBuilder._sync_with_dist_git')
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies')
     target = str(tmpdir.mkdir('target'))
     desc_part = {'packages': {'repositories': [{'name': 'foo',

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -83,7 +83,8 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None,
+            'sync_only': False
         }
     ),
     # Test setting user for OSBS
@@ -94,7 +95,7 @@ def _get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
             'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None,
-            'commit_message': None
+            'commit_message': None, 'sync_only': False
         }
     ),
     # Test setting stage environment for OSBS
@@ -104,7 +105,8 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None,
+            'sync_only': False, 'sync_only': False
         }
     ),
     # Test setting nowait for OSBS
@@ -114,7 +116,8 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': True,
-            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None
+            'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None,
+            'sync_only': False
         }
     ),
     (
@@ -141,7 +144,8 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'release': False,
-            'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None
+            'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None,
+            'sync_only': False
         }),
     (
         ['build', 'docker'],

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -84,7 +84,7 @@ def _get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
             'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None,
-            'sync_only': False
+            'sync_only': False, 'assume_yes': False
         }
     ),
     # Test setting user for OSBS
@@ -95,7 +95,7 @@ def _get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
             'release': False, 'tech_preview': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None,
-            'commit_message': None, 'sync_only': False
+            'commit_message': None, 'sync_only': False, 'assume_yes': False
         }
     ),
     # Test setting stage environment for OSBS
@@ -106,7 +106,7 @@ def _get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
             'release': False, 'tech_preview': False, 'user': None, 'stage': True, 'koji_target': None, 'commit_message': None,
-            'sync_only': False, 'sync_only': False
+            'sync_only': False, 'sync_only': False, 'assume_yes': False
         }
     ),
     # Test setting nowait for OSBS
@@ -117,7 +117,7 @@ def _get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': True,
             'release': False, 'tech_preview': False, 'user': None, 'stage': False, 'koji_target': None, 'commit_message': None,
-            'sync_only': False
+            'sync_only': False, 'assume_yes': False
         }
     ),
     (
@@ -145,7 +145,7 @@ def _get_class_by_name(clazz):
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'release': False,
             'tech_preview': False, 'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'commit_message': None,
-            'sync_only': False
+            'sync_only': False, 'assume_yes': False
         }),
     (
         ['build', 'docker'],


### PR DESCRIPTION
This is a one-off release to backport two features into the 3.3.x codebase:

1. Support for `--assume-yes` OSBS builder switch
1. Support for `--sync-only` OSBS builder switch