### PR TITLE
Remove --koji-target OSBS builder parameter from CLI

### DIFF
--- a/cekit/builder.py
+++ b/cekit/builder.py
@@ -80,11 +80,6 @@ class Builder(Command):
                                         self.params.target,
                                         self.params.overrides)
 
-        if self.params.get('koji_target', False):
-            LOGGER.warning("The '--koji-target' switch is deprecated, please use overrides " +
-                           "(http://docs.cekit.io/en/latest/handbook/overrides.html) to adjust the koji " +
-                           "target, '--koji-target' will be removed in version 3.6")
-
         if CONFIG.get('common', 'redhat'):
             # Add the redhat specific stuff after everything else
             self.generator.add_redhat_overrides()

--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -258,11 +258,6 @@ class OSBSBuilder(Builder):
                 # Default to computed target based on branch
                 target = "{}-containers-candidate".format(self.dist_git.branch)
 
-            # Check if it was specified on command line
-            # TODO: Remove in 3.6
-            if self.params.koji_target:
-                target = self.params.koji_target
-
             scratch = True
 
             if self.params.release:

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -144,13 +144,11 @@ def build_podman(ctx, pull, no_squash, tags):  # pylint: disable=unused-argument
 @click.option('--user', metavar="USER", help="User used to kick the build as.")
 @click.option('--nowait', help="Do not wait for the task to finish.", is_flag=True)
 @click.option('--stage', help="Use stage environmen.", is_flag=True)
-# TODO: Remove in 3.6
-@click.option('--koji-target', metavar="TARGET", help="Override the default Koji target.")
 @click.option('--sync-only', help="Generate files and sync with dist-git, but do not execute build.", is_flag=True)
 @click.option('--commit-message', metavar="MESSAGE", help="Custom dist-git commit message.")
 @click.option('--assume-yes', '-y', help="Execute build in non-interactive mode.", is_flag=True)
 @click.pass_context
-def build_osbs(ctx, release, user, nowait, stage, koji_target, sync_only, commit_message, assume_yes):  # pylint: disable=unused-argument
+def build_osbs(ctx, release, user, nowait, stage, sync_only, commit_message, assume_yes):  # pylint: disable=unused-argument
     """
     DESCRIPTION
 

--- a/docs/handbook/building/builder-engines.rst
+++ b/docs/handbook/building/builder-engines.rst
@@ -133,10 +133,6 @@ Parameters
         Do not wait for the task to finish
     ``--stage``
         Use stage environment
-    ``--koji-target``
-        .. deprecated:: 3.5
-
-        Overrides the default ``koji`` target
     ``--commit-message``
         Custom commit message for dist-git
     ``--sync-only``

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -264,22 +264,6 @@ def test_osbs_builder_run_brew_user(mocker):
                                      "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}"])
 
 
-def test_osbs_builder_run_brew_target_defined_on_cli(mocker):
-    config.cfg['common'] = {'redhat': True}
-    params = {'koji_target': 'Foo'}
-
-    check_output = mocker.patch.object(subprocess, 'check_output', autospec=True, side_effect=[
-                                       b'ssh://user:password@something.redhat.com/containers/openjdk', b'c5a0731b558c8a247dd7f85b5f54462cd5b68b23', b'12345'])
-    builder = create_builder_object(mocker, 'osbs', params)
-    builder.generator = Map({'image': Map({})})
-    mocker.patch.object(builder, '_wait_for_osbs_task')
-    builder.dist_git.branch = "some-branch"
-    builder.run()
-
-    check_output.assert_called_with(['/usr/bin/brew', 'call', '--python', 'buildContainer', '--kwargs',
-                                     "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'Foo', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}"])
-
-
 def test_osbs_builder_run_brew_target_defined_in_descriptor(mocker):
     config.cfg['common'] = {'redhat': True}
 

--- a/tests/test_integ_builder_osbs.py
+++ b/tests/test_integ_builder_osbs.py
@@ -448,24 +448,3 @@ def test_osbs_builder_with_koji_target_in_descriptor(tmpdir, mocker, caplog):
     run_osbs(descriptor, str(tmpdir), mocker)
 
     assert "About to execute '/usr/bin/brew call --python buildContainer --kwargs {'src': 'git://somehost.com/containers/somerepo#3b9283cb26b35511517ff5c0c3e11f490cba8feb', 'target': 'some-target', 'opts': {'scratch': True, 'git_branch': 'branch', 'yum_repourls': []}}'." in caplog.text
-
-
-# TODO: Remove in 3.6
-def test_osbs_builder_with_koji_target_in_descriptor_and_overriden_in_cli(tmpdir, mocker, caplog):
-    mocker.patch('cekit.tools.decision', return_value=True)
-    mocker.patch('cekit.descriptor.resource.urlopen')
-    mocker.patch.object(subprocess, 'call')
-    mocker.patch.object(subprocess, 'check_call')
-
-    tmpdir.mkdir('osbs').mkdir('repo').mkdir(
-        '.git').join('other').write_text(u'Some content', 'utf8')
-
-    descriptor = image_descriptor.copy()
-
-    descriptor['osbs']['koji_target'] = 'some-target'
-
-    run_osbs(descriptor, str(tmpdir), mocker, build_command=[
-             'build', 'osbs', '--koji-target', 'custom-target'])
-
-    assert "The '--koji-target' switch is deprecated, please use overrides (http://docs.cekit.io/en/latest/handbook/overrides.html) to adjust the koji target, '--koji-target' will be removed in version 3.6" in caplog.text
-    assert "About to execute '/usr/bin/brew call --python buildContainer --kwargs {'src': 'git://somehost.com/containers/somerepo#3b9283cb26b35511517ff5c0c3e11f490cba8feb', 'target': 'custom-target', 'opts': {'scratch': True, 'git_branch': 'branch', 'yum_repourls': []}}'." in caplog.text

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -83,7 +83,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'user': None, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None, 'assume_yes': False
+            'release': False, 'user': None, 'stage': False, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
     # Test setting user for OSBS
@@ -93,7 +93,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'user': 'SOMEUSER', 'stage': False, 'koji_target': None, 'sync_only': False,
+            'release': False, 'user': 'SOMEUSER', 'stage': False, 'sync_only': False,
             'commit_message': None, 'assume_yes': False
         }
     ),
@@ -104,7 +104,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
-            'release': False, 'user': None, 'stage': True, 'koji_target': None, 'sync_only': False, 'commit_message': None, 'assume_yes': False
+            'release': False, 'user': None, 'stage': True, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
     # Test setting nowait for OSBS
@@ -114,7 +114,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': True,
-            'release': False, 'user': None, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None, 'assume_yes': False
+            'release': False, 'user': None, 'stage': False, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
     (
@@ -141,7 +141,7 @@ def _get_class_by_name(clazz):
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'release': False,
-            'user': None, 'nowait': False, 'stage': False, 'koji_target': None, 'sync_only': False, 'commit_message': None, 'assume_yes': False
+            'user': None, 'nowait': False, 'stage': False, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }),
     (
         ['build', 'docker'],


### PR DESCRIPTION
It was deprecated in 3.5. In this version we remove it.

Fixes #601