### PR TITLE
Add rh-requirements.txt: for RH workflows

### DIFF
--- a/rh-requirements.txt
+++ b/rh-requirements.txt
@@ -1,0 +1,16 @@
+# Here are listed optional Cekit dependencies that are needed for
+# specific Cekit workflows used in Red Hat.
+
+# for docker build back-end
+docker       >=4.0.2
+docker-squash>=1.0.7
+
+# for content sets
+odcs         >=0.2.35
+
+# for unit tests
+behave       >=1.2.6
+lxml         >=4.4.1
+
+# for koji builds
+koji         >=1.18.0


### PR DESCRIPTION
These packages are optional/soft Cekit dependencies that are required
for some of the workflows most likely used by Red Hat engineers.

This is a time-saver for those who install cekit via pip into a virtualenv. We set up an entirely new virtualenv for each cekit release, and need to then install these same dependencies each time.