### PR TITLE
Do not leave fetch-artifacts-url.yaml if not used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - run: cd ~/.local/bin && curl -L https://github.com/openshift/source-to-image/releases/download/v1.1.13/source-to-image-v1.1.13-b54d75d3-linux-amd64.tar.gz | tar xvz
       - run: pyenv local 2.7.12 3.5.2 3.6.5 3.7.0
       - run: echo -e "[registries.search]\nregistries = ['docker.io', 'registry.fedoraproject.org', 'registry.access.redhat.com']" | sudo tee -a /etc/containers/registries.conf
+      - run: git config --global user.email "ci@dummy.com" && git config --global user.name "John Doe"
       - run: |
           if [[ "${CIRCLE_NODE_INDEX}" == 0 ]]; then
              make test-py27

--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -360,12 +360,17 @@ class DistGit(object):
         with Chdir(self.output):
             git_files = subprocess.check_output(
                 ["git", "ls-files", "."]).strip().decode("utf8").splitlines()
+
             for d in ["repos", "modules"]:
                 LOGGER.info("Removing old '{}' directory".format(d))
                 shutil.rmtree(d, ignore_errors=True)
 
                 if d in git_files:
                     subprocess.check_call(["git", "rm", "-rf", d])
+
+            if os.path.exists("fetch-artifacts-url.yaml"):
+                LOGGER.info("Removing old 'fetch-artifacts-url.yaml' file")
+                subprocess.check_call(["git", "rm", "-rf", "fetch-artifacts-url.yaml"])
 
     def add(self, artifacts):
         LOGGER.debug("Adding files to git stage...")

--- a/cekit/generator/osbs.py
+++ b/cekit/generator/osbs.py
@@ -82,7 +82,7 @@ class OSBSGenerator(Generator):
                                                 'url': get_brew_url(artifact['md5']),
                                                 'target': os.path.join(artifact['target'])})
                     artifact['target'] = os.path.join('artifacts', artifact['target'])
-                    logger.debug("Artifact added to fetch-artifacts-url.yaml")
+                    logger.debug("Artifact '{}' added to fetch-artifacts-url.yaml".format(artifact['name']))
                 except:
                     logger.warning("Plain artifact {} could not be found in Brew, trying to handle it using lookaside cache".
                                    format(artifact['name']))
@@ -93,8 +93,10 @@ class OSBSGenerator(Generator):
             else:
                 artifact.copy(target_dir)
 
+        fetch_artifacts_file = os.path.join(self.target, 'image', 'fetch-artifacts-url.yaml')
+
         if fetch_artifacts_url:
-            with open(os.path.join(self.target, 'image', 'fetch-artifacts-url.yaml'), 'w') as _file:
+            with open(fetch_artifacts_file, 'w') as _file:
                 yaml.safe_dump(fetch_artifacts_url, _file, default_flow_style=False)
 
         logger.debug("Artifacts handled")


### PR DESCRIPTION
If all artifacts are handled by lookaside cache
(or there are no artifacts) we want to make sure the
fetch-artifacts-url.yaml does not exists in the dist-git
repository.

Fixes #629