### PR TITLE
Fix content sets overrides

### DIFF
--- a/tests/test_unit_image.py
+++ b/tests/test_unit_image.py
@@ -58,6 +58,108 @@ def test_image_overrides_with_content_sets_file_none(mocker):
     assert 'content_sets_file' not in image.packages
 
 
+def test_image_overrides_with_content_sets():
+    image = Image(yaml.safe_load("""
+    from: foo
+    name: test/foo
+    version: 1.9
+    packages:
+      install:
+        - abc
+        - def
+      content_sets:
+        arch:
+          - namea
+          - nameb
+    """), 'foo')
+
+    assert image.packages.content_sets == {'arch': ['namea', 'nameb']}
+    assert 'content_sets_file' not in image.packages
+
+    image.apply_image_overrides(
+        [Overrides({'packages': {'content_sets': {'arch': ['new-arch']}}}, "a/path")])
+
+    assert image.packages.content_sets == {'arch': ['new-arch']}
+    assert 'content_sets_file' not in image.packages
+
+
+def test_image_overrides_with_content_sets_file(mocker):
+    image = Image(yaml.safe_load("""
+    from: foo
+    name: test/foo
+    version: 1.9
+    packages:
+      install:
+        - abc
+        - def
+      content_sets:
+        arch:
+          - namea
+          - nameb
+    """), 'foo')
+
+    assert image.packages.content_sets == {'arch': ['namea', 'nameb']}
+    assert 'content_sets_file' not in image.packages
+
+    with mocker.mock_module.patch('cekit.descriptor.packages.os.path.exists') as exists_mock:
+        exists_mock.return_value = True
+        with mocker.mock_module.patch('cekit.descriptor.packages.open', mocker.mock_open(read_data='{"arch": ["a", "b"]}')):
+            image.apply_image_overrides(
+                [Overrides({'packages': {'content_sets_file': 'some-path'}}, "a/path")])
+
+    assert image.packages.content_sets == {'arch': ['a', 'b']}
+    assert 'content_sets_file' not in image.packages
+
+
+def test_image_overrides_packages_repositories_add():
+    image = Image(yaml.safe_load("""
+        from: foo
+        name: test/foo
+        version: 1.9
+        packages:
+            repositories:
+                - name: scl
+                  rpm: centos-release-scl
+        """), 'foo')
+
+    assert len(image.packages.repositories) == 1
+    assert image.packages.repositories[0].rpm == 'centos-release-scl'
+    assert image.packages.repositories[0].name == 'scl'
+
+    image.apply_image_overrides(
+        [Overrides({'packages': {'repositories': [{"id": "rhel7-extras-rpm", "name": "extras"}]}}, "a/path")])
+
+    assert len(image.packages.repositories) == 2
+    assert image.packages.repositories[0].rpm == 'centos-release-scl'
+    assert image.packages.repositories[0].name == 'scl'
+    assert image.packages.repositories[1].id == 'rhel7-extras-rpm'
+    assert image.packages.repositories[1].name == 'extras'
+
+
+def test_image_overrides_packages_repositories_replace():
+    image = Image(yaml.safe_load("""
+        from: foo
+        name: test/foo
+        version: 1.9
+        packages:
+            repositories:
+                - name: scl
+                  rpm: centos-release-scl
+        """), 'foo')
+
+    assert len(image.packages.repositories) == 1
+    assert image.packages.repositories[0].rpm == 'centos-release-scl'
+    assert image.packages.repositories[0].name == 'scl'
+
+    image.apply_image_overrides(
+        [Overrides({'packages': {'repositories': [{"id": "rhel7-extras-rpm", "name": "scl"}]}}, "a/path")])
+
+    assert len(image.packages.repositories) == 1
+    assert image.packages.repositories[0].name == 'scl'
+    assert image.packages.repositories[0].id == 'rhel7-extras-rpm'
+    assert 'rpm' not in image.packages.repositories[0]
+
+
 def test_module_processing_simple_modules_order_to_install():
     image = Image(yaml.safe_load("""
         from: foo


### PR DESCRIPTION
This rewrites how overrides are handled for content sets.
From now all the work to merge packages is offloaded to the merge
algorithm.

Fixes #628