### PR TITLE
Allow for anything in module git ref

### DIFF
--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -18,7 +18,7 @@ from cekit.config import Config
 from cekit.crypto import SUPPORTED_HASH_ALGORITHMS, check_sum
 from cekit.descriptor import Descriptor
 from cekit.errors import CekitError
-from cekit.tools import get_brew_url, Map
+from cekit.tools import get_brew_url, Map, Chdir
 
 logger = logging.getLogger('cekit')
 config = Config()
@@ -437,10 +437,15 @@ class _GitResource(Resource):
         return os.path.basename(descriptor.get('git', {}).get('url')).split(".", 1)[0]
 
     def _copy_impl(self, target):
-        cmd = ['git', 'clone', '--depth', '1', self.git.url, target, '-b',
-               self.git.ref]
-        logger.debug("Running '{}'".format(' '.join(cmd)))
+        cmd = ['git', 'clone', self.git.url, target]
+        logger.debug("Cloning Git repository: '{}'".format(' '.join(cmd)))
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+
+        with Chdir(target):
+            cmd = ['git', 'checkout', self.git.ref]
+            logger.debug("Checking out '{}' ref: '{}'".format(self.git.ref, ' '.join(cmd)))
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+
         return target
 
 


### PR DESCRIPTION
This makes it possible to use any valid reference as the
'ref' value for a Git resource. This type of resource is used
for example for defining module registries.

This accepts now branch, tag, commit or any other valid ref.

Fixes #618