### PR TITLE
Fix osbs section merging

### DIFF
--- a/cekit/descriptor/osbs.py
+++ b/cekit/descriptor/osbs.py
@@ -98,7 +98,6 @@ class Configuration(Descriptor):
         self.schema = configuration_schema
         self.descriptor_path = descriptor_path
         super(Configuration, self).__init__(descriptor)
-        self.skip_merging = ['container', 'container_file']
 
         if 'container' in self and 'container_file' in self:
             raise CekitError('You cannot specify container and container_file together!')

--- a/tests/test_integ_builder_osbs.py
+++ b/tests/test_integ_builder_osbs.py
@@ -59,9 +59,12 @@ def run_cekit(cwd,
         return result
 
 
-def run_osbs(descriptor, image_dir, mocker, return_code=0, build_command=None):
+def run_osbs(descriptor, image_dir, mocker, return_code=0, build_command=None, general_command=None):
     if build_command is None:
         build_command = ['build', 'osbs']
+
+    if general_command is None:
+        general_command = ['--redhat']
 
     # We are mocking it, so do not require it at test time
     mocker.patch('cekit.builders.osbs.OSBSBuilder.dependencies', return_value={})
@@ -82,14 +85,10 @@ def run_osbs(descriptor, image_dir, mocker, return_code=0, build_command=None):
         b"UUU"
     ])
 
-    with open(os.path.join(image_dir, 'config'), 'w') as fd:
-        fd.write("[common]\n")
-        fd.write("redhat = True")
-
     with open(os.path.join(image_dir, 'image.yaml'), 'w') as fd:
         yaml.dump(descriptor, fd, default_flow_style=False)
 
-    return run_cekit(image_dir, ['-v',
+    return run_cekit(image_dir, general_command + ['-v',
                                  '--work-dir', image_dir,
                                  '--config', 'config'] + build_command,
                      return_code=return_code)
@@ -521,3 +520,37 @@ def test_osbs_builder_with_fetch_artifacts_file_removal(tmpdir, mocker, caplog):
 
     assert not os.path.exists(os.path.join(str(tmpdir), 'osbs', 'repo', 'fetch-artifacts-url.yaml'))
     assert "Removing old 'fetch-artifacts-url.yaml' file" in caplog.text
+
+
+@pytest.mark.parametrize('flag', [[], ['--redhat']])
+def test_osbs_builder_container_yaml_existence(tmpdir, mocker, caplog, flag):
+    """
+    Make sure that the osbs section is properly merged.
+    The evidence is that the container.yaml file is generated.
+
+    https://github.com/cekit/cekit/issues/631
+    """
+
+    caplog.set_level(logging.DEBUG, logger="cekit")
+
+    mocker.patch('cekit.tools.decision', return_value=True)
+    mocker.patch('cekit.descriptor.resource.urlopen')
+    mocker.patch('cekit.generator.osbs.get_brew_url', return_value='http://random.url/path')
+    mocker.patch.object(subprocess, 'check_output')
+    mocker.patch('cekit.builders.osbs.DistGit.push')
+
+    tmpdir.mkdir('osbs').mkdir('repo')
+
+    with Chdir(os.path.join(str(tmpdir), 'osbs', 'repo')):
+        subprocess.call(["git", "init"])
+        subprocess.call(["touch", "file"])
+        subprocess.call(["git", "add", "file"])
+        subprocess.call(["git", "commit", "-m", "Dummy"])
+
+    descriptor = image_descriptor.copy()
+
+    descriptor["osbs"]["configuration"] = {'container': {'compose': {'pulp_repos': True}}}
+
+    run_osbs(descriptor, str(tmpdir), mocker, general_command=flag)
+
+    assert os.path.exists(os.path.join(str(tmpdir), 'osbs', 'repo', 'container.yaml'))


### PR DESCRIPTION
Make sure that the osbs section can be correctly merged with overrides.
In some cases the container.yaml file was not generated to incorrect
handling of merging.

Fixes #631