### PR TITLE
Print missing module version warning only when needed

### DIFF
--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -526,7 +526,7 @@ class ModuleRegistry(object):
 
             default_module = self.get_module(name, default_version)
 
-            if not suppress_warnings:
+            if not suppress_warnings and len(modules) > 1:
                 LOGGER.warning("Module version not specified for '{}' module, using '{}' default version".format(
                     name, default_version))
 


### PR DESCRIPTION
When retrieving modules from registry, in case of missing
version, we print  warning only when there are more than one
module in registry with the same name.

Fixes #617