### PR TITLE
Handle artifacts defined in builder images

### DIFF
--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -49,6 +49,7 @@ class Generator(object):
         self._module_registry = ModuleRegistry()
         self.image = None
         self.builder_images = []
+        self.images = []
 
         if overrides:
             for override in overrides:
@@ -106,19 +107,27 @@ class Generator(object):
 
         self.image = Image(descriptor, os.path.dirname(os.path.abspath(self._descriptor_path)))
 
-        # apply overrides to the image definition
-        self.image.apply_image_overrides(self._overrides)
+        # Construct list of all images (builder images + main one)
+        self.images = [self.image] + self.builder_images
 
-        for builder in self.builder_images:
-            builder.apply_image_overrides(self._overrides)
+        for image in self.images:
+            # Apply overrides to all image definitions:
+            # intermediate (builder) images and target image as well
+            # It is required to build the module registry
+            image.apply_image_overrides(self._overrides)
 
-        # add build labels
-        self.add_build_labels()
-        # load the definitions of the modules
+        # Load definitions of modules
+        # We need to load it after we apply overrides so that any changes to modules
+        # will be reflected there as well
         self.build_module_registry()
-        # process included modules
-        self.image.apply_module_overrides(self._module_registry)
-        self.image.process_defaults()
+
+        for image in self.images:
+            # Process included modules
+            image.apply_module_overrides(self._module_registry)
+            image.process_defaults()
+
+        # Add build labels
+        self.add_build_labels()
 
     def generate(self, builder):  # pylint: disable=unused-argument
         self.copy_modules()
@@ -166,12 +175,9 @@ class Generator(object):
 
         modules = []
 
-        for builder in self.builder_images:
-            if builder.modules:
-                modules += [builder.modules]
-
-        if self.image.modules:
-            modules += [self.image.modules]
+        for image in self.images:
+            if image.modules:
+                modules += [image.modules]
 
         return modules
 

--- a/cekit/generator/docker.py
+++ b/cekit/generator/docker.py
@@ -23,14 +23,12 @@ class DockerGenerator(Generator):
         """Goes through artifacts section of image descriptor
         and fetches all of them
         """
-        if not self.image.all_artifacts:
-            logger.debug("No artifacts to fetch")
-            return
 
         logger.info("Handling artifacts...")
         target_dir = os.path.join(self.target, 'image')
 
-        for artifact in self.image.all_artifacts:
-            artifact.copy(target_dir)
+        for image in self.images:
+            for artifact in image.all_artifacts:
+                artifact.copy(target_dir)
 
         logger.debug("Artifacts handled")

--- a/cekit/generator/osbs.py
+++ b/cekit/generator/osbs.py
@@ -64,34 +64,33 @@ class OSBSGenerator(Generator):
         """Goes through artifacts section of image descriptor
         and fetches all of them
         """
-        if not self.image.all_artifacts:
-            logger.debug("No artifacts to fetch")
-            return
 
         logger.info("Handling artifacts...")
         target_dir = os.path.join(self.target, 'image')
         fetch_artifacts_url = []
 
-        for artifact in self.image.all_artifacts:
-            logger.info("Preparing artifact {}".format(artifact['name']))
+        for image in self.images:
+            for artifact in image.all_artifacts:
+                logger.info("Preparing artifact {}".format(artifact['name']))
 
-            if isinstance(artifact, _PlainResource) and \
-               config.get('common', 'redhat'):
-                try:
-                    fetch_artifacts_url.append({'md5': artifact['md5'],
-                                                'url': get_brew_url(artifact['md5']),
-                                                'target': os.path.join(artifact['target'])})
-                    artifact['target'] = os.path.join('artifacts', artifact['target'])
-                    logger.debug("Artifact '{}' added to fetch-artifacts-url.yaml".format(artifact['name']))
-                except:
-                    logger.warning("Plain artifact {} could not be found in Brew, trying to handle it using lookaside cache".
-                                   format(artifact['name']))
+                if isinstance(artifact, _PlainResource) and \
+                        config.get('common', 'redhat'):
+                    try:
+                        fetch_artifacts_url.append({'md5': artifact['md5'],
+                                                    'url': get_brew_url(artifact['md5']),
+                                                    'target': os.path.join(artifact['target'])})
+                        artifact['target'] = os.path.join('artifacts', artifact['target'])
+                        logger.debug(
+                            "Artifact '{}' added to fetch-artifacts-url.yaml".format(artifact['name']))
+                    except:
+                        logger.warning("Plain artifact {} could not be found in Brew, trying to handle it using lookaside cache".
+                                       format(artifact['name']))
+                        artifact.copy(target_dir)
+                        # TODO: This is ugly, rewrite this!
+                        artifact['lookaside'] = True
+
+                else:
                     artifact.copy(target_dir)
-                    # TODO: This is ugly, rewrite this!
-                    artifact['lookaside'] = True
-
-            else:
-                artifact.copy(target_dir)
 
         fetch_artifacts_file = os.path.join(self.target, 'image', 'fetch-artifacts-url.yaml')
 

--- a/tests/images/multi-stage/modules/build/build.sh
+++ b/tests/images/multi-stage/modules/build/build.sh
@@ -5,3 +5,5 @@ echo "This is an application built in builder image" > /path/to/application/insi
 
 mkdir -p /path/to
 echo "This is a library built in builder image" > /path/to/lib.jar
+
+stat /tmp/artifacts/ant.tar.gz

--- a/tests/images/multi-stage/modules/build/module.yaml
+++ b/tests/images/multi-stage/modules/build/module.yaml
@@ -1,5 +1,10 @@
 name: build
 version: 1.0
 
+artifacts:
+  - name: ant.tar.gz
+    url: https://downloads.apache.org//ant/binaries/apache-ant-1.10.8-bin.zip
+    sha512: 24a49f9efd19d1202700192ba811e4a0a714b2e16a37ca8124309ddec6754a22fa12c7e5a07d35a41a104c6b6bb514d5c99a2438b758e5b6c75cc583a2b2385f
+
 execute:
     - script: build.sh


### PR DESCRIPTION
This fixes an issue if an artifact was defined in a builder image, CEKit
failed to handle it. Now, CEKit properly obtains the artifacts and it becomes
available for consumption.

Fixes #642