### PR TITLE
Properly handle package managers in multi-stage builds

### DIFF
--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -74,10 +74,11 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
  # 8. Executes any defined scripts
  # 9. Exposes any defined volumes
  #}
-{%- macro process_module(module, is_image=false) %}
+{%- macro process_module(module, parent_image=None) %}
 {% set module_type = 'module' %}
-{% if is_image %}
+{% if not parent_image %}
 {% set module_type = 'image' %}
+{% set parent_image = module %}
 {% endif %}
 ###### START {{ module_type }} '{{ module.name }}:{{ module.version }}'
 ###### \
@@ -100,7 +101,7 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
         {% endif -%}
 
         {% if module.execute %}
-        {% if not is_image %}
+        {% if module_type == 'module' %}
         # Copy '{{ module.name }}' {{ module_type }} content
         COPY modules/{{ module.name }} /tmp/scripts/{{ module.name }}
         {% endif -%}
@@ -110,7 +111,7 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
         # Switch to 'root' user to install '{{ module.name }}' {{ module_type }} defined packages
         USER root
         # Install packages defined in the '{{ module.name }}' {{ module_type }}
-        RUN {{ pkg_install(image.packages.manager, module.packages.install) }}
+        RUN {{ pkg_install(parent_image.packages.manager, module.packages.install) }}
         {% endif -%}
 
         {% if module.envs|selectattr("value")|list|length > 0 %}
@@ -181,9 +182,9 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
     {% endif %}
 
     {% for to_install in animage.modules.install %}
-{{ process_module(helper.module(to_install)) }}
+{{ process_module(helper.module(to_install), animage) }}
     {% endfor %}
-{{ process_module(animage, true) }}
+{{ process_module(animage) }}
 {%- endmacro -%}
 
 # Copyright 2019 Red Hat

--- a/tests/images/multi-stage/image.yaml
+++ b/tests/images/multi-stage/image.yaml
@@ -15,8 +15,11 @@
 
 - name: some/app
   version: 12
-  from: centos:7
+  from: alpine:3.12
   description: Our application
+
+  packages:
+    manager: apk
 
   modules:
     repositories:

--- a/tests/images/multi-stage/modules/app/module.yaml
+++ b/tests/images/multi-stage/modules/app/module.yaml
@@ -3,7 +3,7 @@ version: 1.0
 
 packages:
    install:
-      - python-requests
+      - py3-requests
 
 artifacts:
     - name: application

--- a/tests/images/multi-stage/modules/setuptools/module.yaml
+++ b/tests/images/multi-stage/modules/setuptools/module.yaml
@@ -3,4 +3,4 @@ version: 1.0
 
 packages:
    install:
-      - python-setuptools
+      - py3-setuptools

--- a/tests/test_integ_podman.py
+++ b/tests/test_integ_podman.py
@@ -29,9 +29,6 @@ def run_cekit(image_dir, args=None, env=None):
 
 @pytest.mark.skipif(platform.system() == 'Darwin', reason="Disabled on macOS, cannot run Podman")
 def test_podman_builder_with_alpine_image(tmpdir):
-    """
-    Build multi-stage image.
-    """
     tmpdir = str(tmpdir)
 
     shutil.copytree(
@@ -46,9 +43,6 @@ def test_podman_builder_with_alpine_image(tmpdir):
 
 @pytest.mark.skipif(platform.system() == 'Darwin', reason="Disabled on macOS, cannot run Podman")
 def test_podman_from_scratch(tmpdir):
-    """
-    Build multi-stage image.
-    """
     tmpdir = str(tmpdir)
 
     shutil.copytree(
@@ -63,9 +57,6 @@ def test_podman_from_scratch(tmpdir):
 
 @pytest.mark.skipif(platform.system() == 'Darwin', reason="Disabled on macOS, cannot run Podman")
 def test_podman_operator_metadata(tmpdir):
-    """
-    Build multi-stage image.
-    """
     tmpdir = str(tmpdir)
 
     shutil.copytree(


### PR DESCRIPTION
In case of multi-stage builds using different images with different
operating systems it is required to specify correct package
managers so that provided packages can be installed properly.

This commit fixes a bug where the package manager specification
was ignored in builder images and instead the target package manager
was used. Now, the specified package manager in the image will be used.

Fixes #646