### PR TITLE
Remove the ASL 2.0 license from generated Dockerfile

### DIFF
--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -187,22 +187,6 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
 {{ process_module(animage) }}
 {%- endmacro -%}
 
-# Copyright 2019 Red Hat
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# ------------------------------------------------------------------------
-#
 # This is a Dockerfile for the {{ name }}:{{ version }} image.
 
 {% for builder_image in builders %}


### PR DESCRIPTION
Licensing of generated files should not be imposed
by the build tool.

Fixes #405