### PR TITLE
Improvements in handling multi-stage builds in OSBS

### DIFF
--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -187,7 +187,7 @@ class Resource(Descriptor):
         if os.path.isdir(target):
             target = os.path.join(target, self.target)
 
-        logger.info("Preparing resource '{}'".format(self.name))
+        logger.info("Copying resource '{}'...".format(self.name))
 
         if os.path.exists(target) and self.__verify(target):
             logger.debug("Local resource '{}' exists and is valid".format(self.name))

--- a/cekit/generator/osbs.py
+++ b/cekit/generator/osbs.py
@@ -71,7 +71,7 @@ class OSBSGenerator(Generator):
 
         for image in self.images:
             for artifact in image.all_artifacts:
-                logger.info("Preparing artifact {}".format(artifact['name']))
+                logger.info("Preparing artifact '{}'".format(artifact['name']))
 
                 if isinstance(artifact, _PlainResource) and \
                         config.get('common', 'redhat'):

--- a/tests/images/multi-stage/image.yaml
+++ b/tests/images/multi-stage/image.yaml
@@ -30,3 +30,8 @@
       - name: setuptools
       # This module is responsible for fetching application built in previous stage
       - name: app
+
+  osbs:
+    repository:
+      name: containers/rhpam-7-operator
+      branch: private-mgoldman-rhba-7-rhel-8

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -147,7 +147,7 @@ class DistGitMock(object):
     def prepare(self, stage, user=None):
         pass
 
-    def clean(self):
+    def clean(self, artifacts):
         pass
 
 

--- a/tests/test_integ_builder_osbs.py
+++ b/tests/test_integ_builder_osbs.py
@@ -423,6 +423,50 @@ def test_osbs_builder_add_files_to_dist_git_when_it_is_a_directory(tmpdir, mocke
     assert "Staging 'manifests'..." in caplog.text
 
 
+def test_osbs_builder_add_artifact_directory_to_dist_git_when_it_already_exists(tmpdir, mocker, caplog):
+    mocker.patch('cekit.tools.decision', return_value=True)
+    mocker.patch.object(subprocess, 'call')
+    mock_check_call = mocker.patch.object(subprocess, 'check_call')
+
+    res = mocker.Mock()
+    res.getcode.return_value = 200
+    res.read.side_effect = [b'test', None]
+
+    mocker.patch('cekit.descriptor.resource.urlopen', return_value=res)
+    #mocker.patch('cekit.builders.osbs.os.path.isdir', side_effect=[False, False, True])
+
+    descriptor = image_descriptor.copy()
+
+    descriptor['artifacts'] = [{'path': 'manifests', 'dest': '/manifests'}]
+
+    tmpdir.mkdir('osbs').mkdir('repo').mkdir(
+        '.git').join('other').write_text(u'Some content', 'utf8')
+
+    tmpdir.join('osbs').join('repo').mkdir('manifests').join(
+        'old-manifests.yaml').write_text(u'Some content', 'utf8')
+
+    tmpdir.mkdir('manifests')
+
+    with open(os.path.join(str(tmpdir), 'manifests', 'some-manifest-file.yaml'), 'w') as _file:
+        _file.write("CONTENT")
+
+    run_osbs(descriptor, str(tmpdir), mocker)
+
+    calls = [
+        mocker.call(['git', 'push', '-q', 'origin', 'branch']),
+        mocker.call(['git', 'commit', '-q', '-m',
+                     'Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb']),
+        mocker.call(['git', 'add', '--all', 'Dockerfile']),
+        mocker.call(['git', 'add', '--all', 'manifests'])
+    ]
+
+    mock_check_call.assert_has_calls(calls, any_order=True)
+    assert len(mock_check_call.mock_calls) == len(calls)
+    assert "Skipping '.git' directory" in caplog.text
+    assert "Staging 'manifests'..." in caplog.text
+    assert "Removing old 'manifests' directory" in caplog.text
+
+
 def test_osbs_builder_add_files_to_dist_git_without_dotgit_directory(tmpdir, mocker, caplog):
     mocker.patch('cekit.tools.decision', return_value=True)
     mocker.patch.object(subprocess, 'call')


### PR DESCRIPTION
Most important change is to take into account artifacts in all images
when preparing the sync with dist-git. Previously only the terget image
was handled which lead to incorrect results.

Other changes:

* Cleaning up dist-git from any untracked files or directories
* More logging

Fixes #649