### PR TITLE
Add OSX and Python matrix testing. Handle 2.7 testing issues.

### DIFF
--- a/.github/workflows/cekit.yml
+++ b/.github/workflows/cekit.yml
@@ -1,16 +1,25 @@
-name: CI
+name: GH-Action Workflow
 
 on:
   push:
-#    branches: master
+    branches:
+      - develop
+      - master
   pull_request:
-#    branches: develop
+    branches:
+      - develop
 
 jobs:
   build:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif
-    #if: github.repository == 'cekit/cekit' && github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
+    if: github.repository == 'cekit/cekit' # && github.event_name == 'pull_request'
+    name: CI Testing
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '2.7', '3.8' ]
+        os: [macos-latest, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Setup cache
@@ -22,8 +31,9 @@ jobs:
           ${{ runner.os }}-pip-
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
-    - name: Install requirements
+        python-version: ${{ matrix.python-version }}
+    - name: Setup Linux
+      if: startsWith(matrix.os,'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get -y install libkrb5-dev software-properties-common containerd runc podman docker.io tox
@@ -37,7 +47,20 @@ jobs:
         git config --global user.email "ci@dummy.com" && git config --global user.name "John Doe"
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         mkdir -p $HOME/.local/bin
-        cd $HOME/.local/bin && curl -L https://github.com/openshift/source-to-image/releases/download/v1.1.13/source-to-image-v1.1.13-b54d75d3-linux-amd64.tar.gz | tar xvz
+        cd $HOME/.local/bin && curl -sL https://github.com/openshift/source-to-image/releases/download/v1.1.13/source-to-image-v1.1.13-b54d75d3-linux-amd64.tar.gz | tar xvz
+        PV=${{ matrix.python-version }}
+        if [ "$PV" == "2.7" ]; then
+          pip install tox zipp==0.5.2 --user
+        fi
+    - name: Setup MacOS
+      if: startsWith(matrix.os,'macos')
+      run: |
+        pip install tox
     - name: Run tests
       run: |
-        make test-py38
+        PV=${{ matrix.python-version }}
+        echo "Running for Python version $PV ( ${PV/./} )"
+        make test-py"${PV/./}"
+#    - name: Setup tmate session (only on failure)
+#      uses: mxschmitt/action-tmate@v3
+#      if: ${{ failure() }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-os: osx
-language: generic
-
-before_script:
-  - pip install tox
-
-script:
-  - make test-py27
-  - make test-py37


### PR DESCRIPTION
@goldmann This removes the use of Travis and uses GH Actions for Python 2.7/3.8 under MacOS and Ubuntu.