### PR TITLE
Change version handling to be zest compatible

### DIFF
--- a/cekit/__init__.py
+++ b/cekit/__init__.py
@@ -1,7 +1,2 @@
-from cekit.version import version
-
-
-__version__ = version
-
 # User used for executing scripts if no "user" is explicitly defined
 DEFAULT_USER = "root"

--- a/cekit/cache/__init__.py
+++ b/cekit/cache/__init__.py
@@ -1,7 +1,2 @@
-from cekit.version import version
-
-
-__version__ = version
-
 # User used for executing scripts if no "user" is explicitly defined
 DEFAULT_USER = "root"

--- a/cekit/cache/cli.py
+++ b/cekit/cache/cli.py
@@ -10,7 +10,7 @@ from cekit.crypto import SUPPORTED_HASH_ALGORITHMS
 from cekit.descriptor.resource import create_resource
 from cekit.log import setup_logging
 from cekit.tools import Map
-from cekit.version import version
+from cekit.version import __version__
 
 setup_logging()
 LOGGER = logging.getLogger('cekit')
@@ -21,7 +21,7 @@ CONFIG = Config()
 @click.option('-v', '--verbose', help="Enable verbose output.", is_flag=True)
 @click.option('--config', metavar="PATH", help="Path to configuration file.", default="~/.cekit/config", show_default=True)
 @click.option('--work-dir', metavar="PATH", help="Location of the working directory.", default="~/.cekit", show_default=True)
-@click.version_option(message="%(version)s", version=version)
+@click.version_option(message="%(version)s", version=__version__)
 def cli(config, verbose, work_dir):  # pylint: disable=unused-argument
     pass
 

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -11,7 +11,7 @@ from cekit.config import Config
 from cekit.errors import CekitError
 from cekit.log import setup_logging
 from cekit.tools import Map
-from cekit.version import version
+from cekit.version import __version__
 
 # FIXME we should try to move this to json
 setup_logging()
@@ -27,7 +27,7 @@ default_work_dir = "~/.cekit"
 @click.option('--config', metavar="PATH", help="Path to configuration file.", default=default_work_dir + "/config", show_default=True)
 @click.option('--redhat', help="Set default options for Red Hat internal infrastructure.", is_flag=True)
 @click.option('--target', metavar="PATH", help="Path to directory where files should be generated", default="target", show_default=True)
-@click.version_option(message="%(version)s", version=version)
+@click.version_option(message="%(version)s", version=__version__)
 def cli(descriptor, verbose, work_dir, config, redhat, target):  # pylint: disable=unused-argument,too-many-arguments
     """
     ABOUT
@@ -290,9 +290,9 @@ class Cekit(object):
         else:
             LOGGER.setLevel(logging.INFO)
 
-        LOGGER.debug("Running version {}".format(version))
+        LOGGER.debug("Running version {}".format(__version__))
 
-        if 'dev' in version or 'rc' in version:
+        if 'dev' in __version__ or 'rc' in __version__:
             LOGGER.warning("You are running unreleased development version of CEKit, "
                            "use it only at your own risk!")
 

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -14,7 +14,7 @@ from cekit.config import Config
 from cekit.descriptor import Env, Image, Label, Module, Overrides, Repository
 from cekit.errors import CekitError
 from cekit.template_helper import TemplateHelper
-from cekit.version import version as cekit_version
+from cekit.version import __version__ as cekit_version
 
 LOGGER = logging.getLogger('cekit')
 CONFIG = Config()

--- a/cekit/version.py
+++ b/cekit/version.py
@@ -1,2 +1,2 @@
-version = "3.9.dev0"
+__version__ = "3.9.dev0"
 schema_version = 2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 sys.path.append(os.path.abspath("./_ext"))
 
-from cekit import version as cekit_version
+from cekit.version import __version__ as cekit_version
 
 
 def setup(app):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from setuptools import setup, find_packages
-from cekit.version import version
+from cekit.version import __version__
 
 import codecs
 
@@ -10,14 +10,14 @@ with open('requirements.txt') as f:
 
 setup(
     name="cekit",
-    version=version,
+    version=__version__,
     packages=find_packages(exclude=["tests"]),
     package_data={
         'cekit.templates': ['*.jinja'],
         'cekit.schema': ['*.yaml'],
     },
     url='https://github.com/cekit/cekit',
-    download_url="https://github.com/cekit/cekit/archive/%s.tar.gz" % version,
+    download_url="https://github.com/cekit/cekit/archive/%s.tar.gz" % __version__,
     author='CEKit team',
     author_email='cekit@cekit.io',
     description='Container image creation tool',

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -7,7 +7,7 @@ import yaml
 from cekit.cli import cli
 from cekit.config import Config
 from cekit.descriptor import Repository
-from cekit.version import version as cekit_version
+from cekit.version import __version__ as cekit_version
 from cekit.tools import Chdir
 
 from click.testing import CliRunner


### PR DESCRIPTION
The current indirection doesn't work with https://zestreleaser.readthedocs.io/en/latest/versions.html so have tried using one of the methods in https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version 