### PR TITLE
added the ability to use Debian based distributions by adding the apt-get package manager

### DIFF
--- a/cekit/descriptor/packages.py
+++ b/cekit/descriptor/packages.py
@@ -21,7 +21,7 @@ map:
   install:
     seq:
       - {type: any}
-  manager: {type: str, enum: ['yum', 'dnf', 'microdnf', 'apk']}""")
+  manager: {type: str, enum: ['yum', 'dnf', 'microdnf', 'apk', 'apt-get']}""")
 
 
 repository_schema = yaml.safe_load("""

--- a/cekit/template_helper.py
+++ b/cekit/template_helper.py
@@ -3,7 +3,7 @@ import os
 
 class TemplateHelper(object):
 
-    SUPPORTED_PACKAGE_MANAGERS = ['yum', 'dnf', 'microdnf', 'apk']
+    SUPPORTED_PACKAGE_MANAGERS = ['yum', 'dnf', 'microdnf', 'apk', 'apt-get']
 
     def __init__(self, module_registry):
         self._module_registry = module_registry
@@ -92,6 +92,19 @@ class TemplateHelper(object):
         default = "--setopt=tsflags=nodocs"
         if "apk" in pkg_mgr:
             return ""
+        if "apt-get" in pkg_mgr:
+            #
+            # This is a HACK...
+            #
+            # Debian based apt-get needs an *update* step
+            # *before* its "install" step...
+            #
+            # We really *should* add an additional step to the
+            # main template repo_install and pkg_install macros
+            #
+            # However this works at the moment...
+            #
+            return "update && apt-get --no-install-recommends"
         elif "microdnf" in pkg_mgr:
             return "--setopt=install_weak_deps=0 " + default
         else:
@@ -106,5 +119,7 @@ class TemplateHelper(object):
     def package_manager_query(self, pkg_mgr):
         if "apk" in pkg_mgr:
             return "apk info -e"
+        elif "apt-get" in pkg_mgr:
+            return "dpkg-query --list"
         else:
             return "rpm -q"

--- a/docs/descriptor/includes/packages.rst
+++ b/docs/descriptor/includes/packages.rst
@@ -34,6 +34,14 @@ as the package manager that is used to manage packages in this image.
         install:
             - python3
 
+.. code-block:: yaml
+    :caption: Example package section for APT-based distro
+
+    packages:
+        manager: apt-get
+        install:
+            - python3-minimal
+
 Packages to install
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -62,7 +70,7 @@ Required
 It is possible to define package manager used in the image
 used to install packages as part of the build process.
 
-Currently available options are ``yum``, ``dnf``, ``microdnf`` and ``apk``.
+Currently available options are ``yum``, ``dnf``, ``microdnf``, ``apt-get`` and ``apk``.
 
 .. note::
     If you do not specify this key the default value is ``yum``.
@@ -73,6 +81,9 @@ Currently available options are ``yum``, ``dnf``, ``microdnf`` and ``apk``.
 
 .. note::
     For ``yum``, ``dnf`` and ``microdnf`` the flag ``--setopt=tsflags=nodocs`` is automatically added. For ``microdnf``, the flag ``--setopt=install_weak_deps=0`` is also added.
+
+-- note::
+    For ``apt-get`` the flag ``--no-install-recommends`` is also added.
 
 .. code-block:: yaml
 

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -359,6 +359,25 @@ def test_supported_package_managers_apk(tmpdir, caplog):
     assert "Package manager apk does not support defining repositories, skipping all repositories" in caplog.text
 
 
+def test_supported_package_managers_apt(tmpdir, caplog):
+    target = str(tmpdir.mkdir('target'))
+
+    generate(
+        target,
+        ['-v', 'build', '--dry-run', 'podman'],
+        descriptor={
+            'packages': {
+                'manager': 'apt-get',
+                'install': ['a'],
+                'repositories': [{'name': 'foo',
+                                  'rpm': 'foo-repo.rpm'}]
+            }
+        })
+    regex_dockerfile(target, "RUN apt-get update && apt-get --no-install-recommends install -y a")
+    regex_dockerfile(target, "dpkg-query --list a")
+    assert "Package manager apt-get does not support defining repositories, skipping all repositories" in caplog.text
+
+
 # https://github.com/cekit/cekit/issues/406
 def test_dockerfile_do_not_copy_modules_if_no_modules(tmpdir):
     target = str(tmpdir.mkdir('target'))

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -856,6 +856,27 @@ def test_run_alpine(tmpdir):
 
     run_cekit(image_dir, parameters=['-v', 'build', 'podman'], env={'BUILDAH_LAYERS': 'false'})
 
+@pytest.mark.skipif(platform.system() == 'Darwin', reason="Disabled on macOS, cannot run Podman")
+def test_run_debian_slim(tmpdir):
+    image_dir = str(tmpdir.mkdir('source'))
+
+    copy_repos(image_dir)
+
+    with open(os.path.join(image_dir, 'bar.jar'), 'w') as fd:
+        fd.write('foo')
+
+    img_desc = image_descriptor.copy()
+    img_desc['from'] = 'debian:stable-slim'
+    img_desc['packages'] = {
+        'install': ['python3-minimal'],
+        'manager': 'apt-get'
+    }
+
+    with open(os.path.join(image_dir, 'image.yaml'), 'w') as fd:
+        yaml.dump(img_desc, fd, default_flow_style=False)
+
+    run_cekit(image_dir, parameters=['-v', 'build', 'podman'], env={'BUILDAH_LAYERS': 'false'})
+
 
 def test_execution_order(tmpdir):
     image_dir = str(tmpdir.mkdir('source'))


### PR DESCRIPTION
This pull request provides changes to (the development branch of) CEKit to allow the use of ``apt-get`` as a package manager.

These changes are based upon the corresponding pull request for the Alpine ``apk`` package manager #612 corresponding to the enhancement issue #609 

Following the example of the PR #612 we have added:
1. changes to the templating system (via template_helper.py),
2. updated the documentation,
3. added (minimal?) tests corresponding to the use of debian-slim and ``apt-get`` as the distribution and its package manager.

**NOTE:** The Debian ``apt-get`` package manager seems to *require* an "update" step *before* its "install" step. To be completely "correct" we *should* refactor the ``repo_install`` and ``pkg_install`` macros in the ``cekit/templates/template.jinja`` file to add an explicit "pre-install" step. However we have, for this PR, simply added ``update && apt-get --no-install-recommends`` to the ``package_manager_flags`` macro in the ``cekit/template_helper.py`` file. (see the PR differences report).

All tests pass against the Python 3.8 interpreter. (``make test``).

Fixes #693