### PR TITLE
Add command-line/configuration option to allow/disallow the use of ODCS content sets

### DIFF
--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -26,9 +26,10 @@ default_work_dir = "~/.cekit"
 @click.option('--work-dir', metavar="PATH", help="Location of the working directory.", default=default_work_dir, show_default=True)
 @click.option('--config', metavar="PATH", help="Path to configuration file.", default=default_work_dir + "/config", show_default=True)
 @click.option('--redhat', help="Set default options for Red Hat internal infrastructure.", is_flag=True)
+@click.option('--allow-odcs/--no-allow-odcs', help="Allow ODCS content sets.", default=True)
 @click.option('--target', metavar="PATH", help="Path to directory where files should be generated", default="target", show_default=True)
 @click.version_option(message="%(version)s", version=version)
-def cli(descriptor, verbose, work_dir, config, redhat, target):  # pylint: disable=unused-argument,too-many-arguments
+def cli(descriptor, verbose, work_dir, config, redhat, allow_odcs, target):  # pylint: disable=unused-argument,too-many-arguments
     """
     ABOUT
 

--- a/cekit/config.py
+++ b/cekit/config.py
@@ -22,7 +22,7 @@ class Config(object):
         # Only allow command line overriding of these values if they are not the default value.
         if cmdline_args.get('redhat'):
             cls.cfg['common']['redhat'] = cmdline_args.get('redhat')
-        if cmdline_args.get("allow_odcs") is not None and cmdline_args.get("allow_odcs") != True:
+        if cmdline_args.get("allow_odcs") is not None:
             cls.cfg['common']['allow_odcs'] = cmdline_args.get('allow_odcs')
         from cekit import cli
         if cmdline_args.get('work_dir') and cmdline_args.get('work_dir') != cli.default_work_dir:

--- a/cekit/config.py
+++ b/cekit/config.py
@@ -22,6 +22,8 @@ class Config(object):
         # Only allow command line overriding of these values if they are not the default value.
         if cmdline_args.get('redhat'):
             cls.cfg['common']['redhat'] = cmdline_args.get('redhat')
+        if cmdline_args.get("allow_odcs") is not None and cmdline_args.get("allow_odcs") != True:
+            cls.cfg['common']['allow_odcs'] = cmdline_args.get('allow_odcs')
         from cekit import cli
         if cmdline_args.get('work_dir') and cmdline_args.get('work_dir') != cli.default_work_dir:
             cls.cfg['common']['work_dir'] = cmdline_args.get('work_dir')
@@ -40,6 +42,8 @@ class Config(object):
         cls.cfg['common']['work_dir'] = cls.cfg.get('common').get('work_dir', '~/.cekit')
         cls.cfg['common']['redhat'] = yaml.safe_load(
             cls.cfg.get('common', {}).get('redhat', 'False'))
+        cls.cfg['common']['allow_odcs'] = yaml.safe_load(
+            cls.cfg.get('common', {}).get('allow_odcs', 'True'))
         cls.cfg['repositories'] = cls.cfg.get('repositories', {})
 
     @classmethod

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -67,13 +67,14 @@ class Generator(object):
     def dependencies(params=None):
         deps = {}
 
-        deps['odcs-client'] = {
-            'package': 'python3-odcs-client',
-            'library': 'odcs',
-            'rhel': {
-                'package': 'python2-odcs-client'
+        if CONFIG.get('common', 'allow_odcs'):
+            deps['odcs-client'] = {
+                'package': 'python3-odcs-client',
+                'library': 'odcs',
+                'rhel': {
+                    'package': 'python2-odcs-client'
+                }
             }
-        }
 
         if CONFIG.get('common', 'redhat'):
             deps['brew'] = {
@@ -389,6 +390,9 @@ class Generator(object):
     def _prepare_content_sets(self, content_sets):
         if not content_sets:
             return False
+
+        if not CONFIG.get('common', 'allow_odcs'):
+            raise CekitError("There are content_sets defined but CEKit is currently configured with allow_odcs=False (--no-allow-odcs)")
 
         arch = platform.machine()
 

--- a/docs/handbook/configuration.rst
+++ b/docs/handbook/configuration.rst
@@ -125,3 +125,13 @@ Example
         [common]
         redhat = True
 
+Allow the use of On Demand Compose Service (ODCS) content sets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Key
+	``allow_odcs``
+Description
+	A boolean which, if True, allows the use of On Demand Compose Service 
+	content sets in CEKit descriptors. 
+Default
+	True	

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -22,7 +22,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': True,
-            'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
+            'allow_odcs': True, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
             'no_squash': False, 'tags': ()
         }
     ),
@@ -32,7 +32,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config', 'redhat': False,
-            'target': 'custom-target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
+            'allow_odcs': True, 'target': 'custom-target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
             'no_squash': False, 'tags': ()
         }
     ),
@@ -42,6 +42,26 @@ def _get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': 'custom-workdir', 'config': '~/.cekit/config',
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
+            'no_squash': False, 'tags': ()
+        }
+    ),
+    # Check --allow-odcs
+    (
+        ['--allow-odcs', 'build', 'docker'],
+        'cekit.builders.docker_builder.DockerBuilder',
+        {
+            'allow_odcs': True, 'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
+            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
+            'no_squash': False, 'tags': ()
+        }
+    ),
+    # Check --no-allow-odcs
+    (
+        ['--no-allow-odcs', 'build', 'docker'],
+        'cekit.builders.docker_builder.DockerBuilder',
+        {
+            'allow_odcs': False, 'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
             'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
             'no_squash': False, 'tags': ()
         }
@@ -52,7 +72,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': 'custom-config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (),  'pull': False,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (),  'pull': False,
             'no_squash': False, 'tags': ()
         }
     ),
@@ -62,7 +82,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
             'no_squash': False, 'tags': ()
         }
     ),
@@ -72,7 +92,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': ('foo', 'bar'),
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': ('foo', 'bar'),
             'pull': False, 'no_squash': False, 'tags': ()
         }
     ),
@@ -82,7 +102,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
             'release': False, 'user': None, 'stage': False, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
@@ -92,7 +112,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
             'release': False, 'user': 'SOMEUSER', 'stage': False, 'sync_only': False,
             'commit_message': None, 'assume_yes': False
         }
@@ -103,7 +123,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': False,
             'release': False, 'user': None, 'stage': True, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
@@ -113,7 +133,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': True,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'nowait': True,
             'release': False, 'user': None, 'stage': False, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }
     ),
@@ -122,7 +142,7 @@ def _get_class_by_name(clazz):
         'cekit.test.behave_tester.BehaveTester',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'overrides': (), 'image': 'image:1.0',
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'overrides': (), 'image': 'image:1.0',
             'steps_url': 'https://github.com/cekit/behave-test-steps.git', 'wip': False, 'names': ()
         }
     ),
@@ -131,7 +151,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': True,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': True,
             'no_squash': False, 'tags': ()
         }
     ),
@@ -140,7 +160,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.osbs.OSBSBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'release': False,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'release': False,
             'user': None, 'nowait': False, 'stage': False, 'sync_only': False, 'commit_message': None, 'assume_yes': False
         }),
     (
@@ -148,7 +168,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.docker_builder.DockerBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False,
             'no_squash': False, 'tags': ()
         }
     ),
@@ -157,7 +177,7 @@ def _get_class_by_name(clazz):
         'cekit.builders.buildah.BuildahBuilder',
         {
             'descriptor': 'image.yaml', 'verbose': False, 'work_dir': '~/.cekit', 'config': '~/.cekit/config',
-            'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'tags': (), 'no_squash': False
+            'allow_odcs': True, 'redhat': False, 'target': 'target', 'validate': False, 'dry_run': False, 'overrides': (), 'pull': False, 'tags': (), 'no_squash': False
         }
     )
 ])


### PR DESCRIPTION
This pull request provides changes to (the development branch of) CEKit to add a command-line/configuration option to allow/disallow the use of ODCS content sets.

In particular *if* the ``--no-allow-odcs`` command-line switch is used (``allow_odcs=False``) then the ``Generator::dependencies`` method does *not* add the ``python3-odcs-client`` dependency and an error is raised if the CEKit descriptor makes use of ``content_sets``.

The **default** remains ``--allow-odcs`` (``allow_odcs=True``). With this default the dependency check for ``python3-odcs-client`` remains and the use of ``content_sets`` are allowed. (This default retains the current behaviour).

*These changes allow the use of CEKit on host distributions, such as Debian/Ubuntu, which do not have ODCS clients.*

Fixes #696