### PR TITLE
Make odcs a runtime requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: "Install required packages"
           command: |
             sudo apt-get update
-            sudo apt install -y graphviz
+            sudo apt install -y graphviz libkrb5-dev
       - checkout
       - run:
           name: Install docs dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: |
             sudo add-apt-repository -y ppa:projectatomic/ppa
             sudo apt-get update
-            sudo apt-get install libkrb5-dev software-properties-common uidmap podman docker-ce
+            sudo apt-get install libkrb5-dev software-properties-common uidmap podman docker-ce libxml2-dev libxslt1-dev
       - checkout
       - run: docker version
       - run: docker info

--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,6 @@ docker-squash = "*"
 click = "*"
 pylint = "*"
 autopep8 = "*"
-odcs = "*"
 "zest.releaser" = "*"
 
 [packages]
@@ -24,6 +23,7 @@ colorlog = ">=2.10.0"
 PyYAML = ">=3.10"
 Jinja2 = ">=2.7"
 click = ">=6.7"
+odcs = ">=0.3.2"
 
 [requires]
 python_version = "*"

--- a/docs/handbook/installation/instructions.rst
+++ b/docs/handbook/installation/instructions.rst
@@ -82,3 +82,11 @@ If you don't want to (or cannot) use Virtualenv, the best idea is to install CEK
 .. note::
     In this case you may need to add ``~/.local/bin/`` directory to your ``$PATH`` environment variable to
     be able to run the ``cekit`` command.
+    
+.. note::
+    For Debian based distros, you *may* need to pre-install the ``libkrb5-dev`` apt package *before*
+    installing cekit using pip (either inside or outside a virtualenv). You can do this by typing:
+
+.. code-block:: bash
+
+    sudo apt install libkrb5-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pykwalify>=1.6.0,<1.8.0
 colorlog>=2.10.0
 click>=6.7
 packaging>=19.0
+odcs>=0.3.2


### PR DESCRIPTION
As mentioned in my reply to #696 odcs is really a *runtime* requirement of cekit.

At the moment it is listed as a development time requirement (in Pipfile).

This pull request fixes both the ``requirement.txt`` and ``Pipfile`` requirements files.

This pull request *also* updates the ``docs/handbook/installation/instructions.rst`` file to add a note to users of Debian based distros, that they may need to pre-install the ``libkrb5-dev`` apt package *before* installing using pip.

This pull request has been tested in a clean Ubuntu focal VM using both pip (directly) and virtualenv. (The pre-installation of ``libkrb5-dev`` is *required* to successfully installing cekit with the new odcs requirement).

Fixes #698 (using a much simpler change).