### PR TITLE
update tomcat module file extention to yaml

### DIFF
--- a/docs/getting-started/modules.rst
+++ b/docs/getting-started/modules.rst
@@ -142,7 +142,7 @@ Tomcat
    chown user:user -R /home/user
 
 .. code-block:: yaml
-   :caption: module.yml
+   :caption: module.yaml
 
    name: tomcat
    version: 1.0


### PR DESCRIPTION
1. change from yml to yaml to keep consistency.
2. I got "CekitError: There are no modules with 'tomcat' name available" when it was yml