### PR TITLE
Docs: Include all keys in top-most OSBS example

### DIFF
--- a/docs/descriptor/includes/image/osbs.rst
+++ b/docs/descriptor/includes/image/osbs.rst
@@ -9,9 +9,12 @@ Required
 This section represents object we use to hint OSBS builder with a configuration which needs to be tweaked
 for successful and reproducible builds.
 
-It contains two main keys:
+It contains five keys:
 
+* :ref:`extra_dir <descriptor/image:OSBS extra directory>`
+* :ref:`extra_dir_target <descriptor/image:OSBS extra copy command>`
 * :ref:`repository <descriptor/image:OSBS repository>`
+* :ref:`koji_target <descriptor/image:OSBS Koji target>`
 * :ref:`configuration <descriptor/image:OSBS configuration>`
 
 

--- a/docs/descriptor/includes/image/osbs.rst
+++ b/docs/descriptor/includes/image/osbs.rst
@@ -18,10 +18,14 @@ It contains two main keys:
 .. code-block:: yaml
 
     osbs:
+        extra_dir: osbs-extra
+        extra_dir_target: /
         repository:
             name: containers/redhat-openjdk-18
             branch: jb-openjdk-1.8-openshift-rhel-7
+        koji_target: rhaos-middleware-rhel-7-containers-candidate
         configuration:
+            gating_file: gating.yaml
             container:
                 compose:
                     pulp_repos: true


### PR DESCRIPTION
Include an example of every (sub) key for OSBS configuration in
the example YAML at the top of the page.

It was not clear enough to me where in the osbs heirarchy the
`koji_target` key belonged from the documentation alone, and I
had to double check by reading the source code.

I've ordered the keys to match the order of descriptions below.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>