### PR TITLE
Issue 779: Change how docker tags are passed to behave tags

### DIFF
--- a/cekit/test/behave_runner.py
+++ b/cekit/test/behave_runner.py
@@ -51,12 +51,13 @@ class BehaveTestRunner(object):
                 args.append("%s" % name)
         else:
             for tag in run_tags:
-                if ":" in tag:
-                    test_tag = tag.split(":")[0]
+
+                # Remove anything after the colon, typically the docker tag.
+                tag = tag.partition(":")[0]
 
                 args.append("-t")
                 if "/" in tag:
-                    args.append("@%s,@%s" % (test_tag.split("/")[0], test_tag))
+                    args.append("@%s,@%s" % (tag.split("/")[0], tag))
                 else:
                     args.append(tag)
 

--- a/tests/test_integ_test_behave.py
+++ b/tests/test_integ_test_behave.py
@@ -31,7 +31,7 @@ image_descriptors = [
         "labels": [{"name": "foo", "value": "bar"}, {"name": "labela", "value": "a"}],
         "envs": [{"name": "baz", "value": "qux"}, {"name": "enva", "value": "a"}],
         "run": {"cmd": ["tail", "-f", "/dev/null"]},
-    }
+    },
 ]
 
 

--- a/tests/test_integ_test_behave.py
+++ b/tests/test_integ_test_behave.py
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 
 import os
-import platform
 import shutil
 import sys
 import tempfile
@@ -68,7 +67,7 @@ def fixture_build_image(request):
     os.path.exists("/var/run/docker.sock") is False, reason="No Docker available"
 )
 def test_execute_simple_behave_test(build_image):
-    feature = """@test
+    feature = """@test @image
 Feature: Basic tests
 
   Scenario: Check that the labels are correctly set


### PR DESCRIPTION
The docker image name (including tag) is passed directly to behave as the name of a test tag if the docker image name does not include a slash. Behave won't accept test tags that have a non-integer value after the colon. Given CEKit design, this means it is not possible to test an image that has a docker tag other than "latest" or something that can be coerced to an integer using python's `int` function. This changes that behaviour to never pass the docker tag on to behave (i.e anything after a colon).

This is intended to fix #779.

However, looking carefully at this bit of code, I can see no way to fix #779 without also changing existing behaviour of CEKit here, which feels to me somewhat convoluted. Therefore, this PR may not be the best way to resolve the problem.