### PR TITLE
Migrate to using subprocess.run. Create a run_wrapper around that. Ad…

### DIFF
--- a/.github/workflows/cekit.yml
+++ b/.github/workflows/cekit.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
         os: [macos-latest, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test: prepare
 	tox -- tests
 
+test-py36: prepare
+	tox -e py36 -- tests
+
 test-py37: prepare
 	tox -e py37 -- tests
 

--- a/cekit/builders/buildah.py
+++ b/cekit/builders/buildah.py
@@ -1,8 +1,8 @@
 import logging
 import os
-import subprocess
 
 from cekit.builder import Builder
+from cekit.tools import run_wrapper
 
 LOGGER = logging.getLogger("cekit")
 
@@ -49,9 +49,7 @@ class BuildahBuilder(Builder):
 
         cmd.append(os.path.join(self.target, "image"))
 
-        LOGGER.debug("Running Buildah build: '{}'".format(" ".join(cmd)))
-
-        subprocess.check_call(cmd)
+        run_wrapper(cmd, False, f"Could not run buildah {cmd}")
 
         LOGGER.info(
             "Image built and available under following tags: {}".format(", ".join(tags))

--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -407,21 +407,15 @@ class DistGit(object):
         if os.path.exists(self.output):
             with Chdir(self.output):
                 LOGGER.info("Fetching latest changes in repo {}...".format(self.repo))
-                subprocess.check_call(["git", "fetch"])
-                # run_wrapper(["git", "fetch"], False)
+                run_wrapper(["git", "fetch"], False)
                 LOGGER.debug("Checking out {} branch...".format(self.branch))
-                subprocess.check_call(["git", "checkout", "-f", self.branch])
-                # run_wrapper(["git", "checkout", "-f", self.branch], False)
+                run_wrapper(["git", "checkout", "-f", self.branch], False)
                 LOGGER.debug("Resetting branch...")
-                subprocess.check_call(
-                    ["git", "reset", "--hard", "origin/%s" % self.branch]
+                run_wrapper(
+                    ["git", "reset", "--hard", "origin/%s" % self.branch], False
                 )
-                # run_wrapper(
-                #     ["git", "reset", "--hard", "origin/%s" % self.branch], False
-                # )
                 LOGGER.debug("Removing any untracked files or directories...")
-                subprocess.check_call(["git", "clean", "-fdx"])
-                # run_wrapper(["git", "clean", "-fdx"], False)
+                run_wrapper(["git", "clean", "-fdx"], False)
             LOGGER.debug("Changes pulled")
         else:
             LOGGER.info(
@@ -439,8 +433,7 @@ class DistGit(object):
                 cmd += ["--user", user]
             cmd += ["-q", "clone", "-b", self.branch, self.repo, self.output]
             LOGGER.debug("Cloning: '{}'".format(" ".join(cmd)))
-            # run_wrapper(cmd, False)
-            subprocess.check_call(cmd)
+            run_wrapper(cmd, False)
             LOGGER.debug("Repository {} cloned".format(self.repo))
 
     def clean(self, artifacts):
@@ -472,13 +465,11 @@ class DistGit(object):
 
             if os.path.exists("fetch-artifacts-url.yaml"):
                 LOGGER.info("Removing old 'fetch-artifacts-url.yaml' file")
-                subprocess.check_call(["git", "rm", "-rf", "fetch-artifacts-url.yaml"])
-                # run_wrapper(["git", "rm", "-rf", "fetch-artifacts-url.yaml"], False)
+                run_wrapper(["git", "rm", "-rf", "fetch-artifacts-url.yaml"], False)
 
             if os.path.exists("fetch-artifacts-pnc.yaml"):
                 LOGGER.info("Removing old 'fetch-artifacts-pnc.yaml' file")
-                subprocess.check_call(["git", "rm", "-rf", "fetch-artifacts-pnc.yaml"])
-                # run_wrapper(["git", "rm", "-rf", "fetch-artifacts-pnc.yaml"], False)
+                run_wrapper(["git", "rm", "-rf", "fetch-artifacts-pnc.yaml"], False)
 
     def add(self, artifacts):
         LOGGER.debug("Adding files to git stage...")
@@ -511,8 +502,7 @@ class DistGit(object):
 
         # Commit the change
         LOGGER.info("Committing with message: '{}'".format(commit_msg))
-        # run_wrapper(["git", "commit", "-q", "-m", commit_msg], False)
-        subprocess.check_call(["git", "commit", "-q", "-m", commit_msg])
+        run_wrapper(["git", "commit", "-q", "-m", commit_msg], False)
         untracked = run_wrapper(
             ["git", "ls-files", "--others", "--exclude-standard"], True
         ).stdout

--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -20,7 +20,7 @@ from cekit.descriptor.resource import (
     _UrlResource,
 )
 from cekit.errors import CekitError
-from cekit.tools import Chdir, copy_recursively
+from cekit.tools import Chdir, copy_recursively, run_wrapper
 
 LOGGER = logging.getLogger("cekit")
 CONFIG = Config()
@@ -224,19 +224,14 @@ class OSBSBuilder(Builder):
         }
 
         # Get information about the task
-        try:
-            json_info = (
-                subprocess.check_output(
-                    [self._koji, "call", "--json-output", "getTaskInfo", task_id]
-                )
-                .strip()
-                .decode("utf-8")
-            )
-        except subprocess.CalledProcessError as ex:
-            raise CekitError("Could not check the task {} result".format(task_id), ex)
+        result = run_wrapper(
+            [self._koji, "call", "--json-output", "getTaskInfo", task_id],
+            True,
+            f"Could not check the task {task_id} result",
+        )
 
         # Parse the returned JSON
-        info = json.loads(json_info)
+        info = json.loads(result.stdout)
 
         # Task is closed which means that it was successfully finished
         if info["state"] == states["closed"]:
@@ -280,9 +275,8 @@ class OSBSBuilder(Builder):
             cmd += ["--user", self.params.user]
         cmd += ["new-sources"] + cache_artifacts
 
-        LOGGER.debug("Executing '{}'".format(cmd))
         with Chdir(self.dist_git_dir):
-            subprocess.check_output(cmd)
+            run_wrapper(cmd, False)
 
         LOGGER.info("Update finished.")
 
@@ -302,17 +296,13 @@ class OSBSBuilder(Builder):
 
         with Chdir(self.dist_git_dir):
             # Get the url of the repository
-            url = (
-                subprocess.check_output(["git", "config", "--get", "remote.origin.url"])
-                .strip()
-                .decode("utf-8")
-            )
+            url = run_wrapper(
+                ["git", "config", "--get", "remote.origin.url"], True
+            ).stdout
+
             # Get the latest commit hash
-            commit = (
-                subprocess.check_output(["git", "rev-parse", "HEAD"])
-                .strip()
-                .decode("utf-8")
-            )
+            commit = run_wrapper(["git", "rev-parse", "HEAD"], True).stdout
+
             # Parse the dist-git repository url
             url = urlparse(url)
             # Construct the url again, with a hash and removed username and password, if any
@@ -346,7 +336,7 @@ class OSBSBuilder(Builder):
                     "Executing {} container build in OSBS...".format(build_type)
                 )
 
-                task_id = subprocess.check_output(cmd).strip().decode("utf-8")
+                task_id = run_wrapper(cmd, True).stdout
 
                 LOGGER.info(
                     "Task {0} was submitted, you can watch the progress here: {1}/taskinfo?taskID={0}".format(
@@ -370,32 +360,21 @@ class DistGit(object):
 
         with Chdir(path):
             if (
-                subprocess.check_output(["git", "rev-parse", "--is-inside-work-tree"])
-                .strip()
-                .decode("utf-8")
+                run_wrapper(["git", "rev-parse", "--is-inside-work-tree"], True).stdout
                 != "true"
             ):
-
                 raise Exception(
                     "Directory {} doesn't seem to be a git repository. "
                     "Please make sure you specified correct path.".format(path)
                 )
 
             name = os.path.basename(
-                subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
-                .strip()
-                .decode("utf-8")
+                run_wrapper(["git", "rev-parse", "--show-toplevel"], True).stdout
             )
-            branch = (
-                subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-                .strip()
-                .decode("utf-8")
-            )
-            commit = (
-                subprocess.check_output(["git", "rev-parse", "HEAD"])
-                .strip()
-                .decode("utf-8")
-            )
+            branch = run_wrapper(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"], True
+            ).stdout
+            commit = run_wrapper(["git", "rev-parse", "HEAD"], True).stdout
 
         return name, branch, commit
 
@@ -417,7 +396,9 @@ class DistGit(object):
     def stage_modified(self):
         # Check if there are any files in stage (return code 1). If there are no files
         # (return code 0) it means that this is a rebuild, so skip committing
-        if subprocess.call(["git", "diff-index", "--quiet", "--cached", "HEAD"]):
+        if run_wrapper(
+            ["git", "diff-index", "--quiet", "--cached", "HEAD"], False, check=False
+        ).returncode:
             return True
 
         return False
@@ -427,14 +408,20 @@ class DistGit(object):
             with Chdir(self.output):
                 LOGGER.info("Fetching latest changes in repo {}...".format(self.repo))
                 subprocess.check_call(["git", "fetch"])
+                # run_wrapper(["git", "fetch"], False)
                 LOGGER.debug("Checking out {} branch...".format(self.branch))
                 subprocess.check_call(["git", "checkout", "-f", self.branch])
+                # run_wrapper(["git", "checkout", "-f", self.branch], False)
                 LOGGER.debug("Resetting branch...")
                 subprocess.check_call(
                     ["git", "reset", "--hard", "origin/%s" % self.branch]
                 )
+                # run_wrapper(
+                #     ["git", "reset", "--hard", "origin/%s" % self.branch], False
+                # )
                 LOGGER.debug("Removing any untracked files or directories...")
                 subprocess.check_call(["git", "clean", "-fdx"])
+                # run_wrapper(["git", "clean", "-fdx"], False)
             LOGGER.debug("Changes pulled")
         else:
             LOGGER.info(
@@ -452,6 +439,7 @@ class DistGit(object):
                 cmd += ["--user", user]
             cmd += ["-q", "clone", "-b", self.branch, self.repo, self.output]
             LOGGER.debug("Cloning: '{}'".format(" ".join(cmd)))
+            # run_wrapper(cmd, False)
             subprocess.check_call(cmd)
             LOGGER.debug("Repository {} cloned".format(self.repo))
 
@@ -467,33 +455,30 @@ class DistGit(object):
                 directory_artifacts.append(artifact)
 
         with Chdir(self.output):
-            git_files = (
-                subprocess.check_output(["git", "ls-files", "."])
-                .strip()
-                .decode("utf-8")
-                .splitlines()
-            )
+            git_files = run_wrapper(["git", "ls-files", "."], True).stdout.splitlines()
 
             for d in ["repos", "modules"] + directory_artifacts:
                 LOGGER.info("Removing old '{}' directory".format(d))
                 shutil.rmtree(d, ignore_errors=True)
 
                 if d in git_files:
-                    subprocess.check_call(["git", "rm", "-rf", d])
+                    run_wrapper(["git", "rm", "-rf", d], False)
 
             if os.path.exists(self.osbs_extra):
                 LOGGER.info(
                     "Removing old osbs extra directory : {}".format(self.osbs_extra)
                 )
-                subprocess.check_call(["git", "rm", "-rf", self.osbs_extra])
+                run_wrapper(["git", "rm", "-rf", self.osbs_extra], False)
 
             if os.path.exists("fetch-artifacts-url.yaml"):
                 LOGGER.info("Removing old 'fetch-artifacts-url.yaml' file")
                 subprocess.check_call(["git", "rm", "-rf", "fetch-artifacts-url.yaml"])
+                # run_wrapper(["git", "rm", "-rf", "fetch-artifacts-url.yaml"], False)
 
             if os.path.exists("fetch-artifacts-pnc.yaml"):
                 LOGGER.info("Removing old 'fetch-artifacts-pnc.yaml' file")
                 subprocess.check_call(["git", "rm", "-rf", "fetch-artifacts-pnc.yaml"])
+                # run_wrapper(["git", "rm", "-rf", "fetch-artifacts-pnc.yaml"], False)
 
     def add(self, artifacts):
         LOGGER.debug("Adding files to git stage...")
@@ -512,7 +497,7 @@ class DistGit(object):
 
             LOGGER.debug("Staging '{}'...".format(obj))
 
-            subprocess.check_call(["git", "add", "--all", obj])
+            run_wrapper(["git", "add", "--all", obj], False)
 
     def commit(self, commit_msg):
         if not commit_msg:
@@ -526,12 +511,11 @@ class DistGit(object):
 
         # Commit the change
         LOGGER.info("Committing with message: '{}'".format(commit_msg))
+        # run_wrapper(["git", "commit", "-q", "-m", commit_msg], False)
         subprocess.check_call(["git", "commit", "-q", "-m", commit_msg])
-
-        untracked = subprocess.check_output(
-            ["git", "ls-files", "--others", "--exclude-standard"]
-        ).decode("utf-8")
-
+        untracked = run_wrapper(
+            ["git", "ls-files", "--others", "--exclude-standard"], True
+        ).stdout
         if untracked:
             LOGGER.warning(
                 "There are following untracked files: {}. Please review your commit.".format(
@@ -539,10 +523,7 @@ class DistGit(object):
                 )
             )
 
-        diffs = subprocess.check_output(["git", "diff-files", "--name-only"]).decode(
-            "utf-8"
-        )
-
+        diffs = run_wrapper(["git", "diff-files", "--name-only"], True).stdout
         if diffs:
             LOGGER.warning(
                 "There are uncommitted changes in following files: '{}'. "
@@ -550,8 +531,8 @@ class DistGit(object):
             )
 
         if not self.noninteractive:
-            subprocess.call(["git", "status"])
-            subprocess.call(["git", "show"])
+            run_wrapper(["git", "status"], False)
+            run_wrapper(["git", "show"], False)
 
         if not (self.noninteractive or tools.decision("Are you ok with the changes?")):
             LOGGER.info(
@@ -573,7 +554,7 @@ class DistGit(object):
             LOGGER.info("Pushing change to the upstream repository...")
             cmd = ["git", "push", "-q", "origin", self.branch]
             LOGGER.debug("Running command '{}'".format(" ".join(cmd)))
-            subprocess.check_call(cmd)
+            run_wrapper(cmd, False)
             LOGGER.info("Change pushed.")
         else:
             LOGGER.info("Changes are not pushed, exiting")

--- a/cekit/builders/podman.py
+++ b/cekit/builders/podman.py
@@ -1,9 +1,8 @@
 import logging
 import os
-import subprocess
 
 from cekit.builder import Builder
-from cekit.errors import CekitError
+from cekit.tools import run_wrapper
 
 LOGGER = logging.getLogger("cekit")
 
@@ -50,15 +49,8 @@ class PodmanBuilder(Builder):
 
         cmd.append(os.path.join(self.target, "image"))
 
-        LOGGER.debug("Running Podman build: '{}'".format(" ".join(cmd)))
+        run_wrapper(cmd, False, f"Could not run podman {cmd}")
 
-        try:
-            subprocess.check_call(cmd)
-
-            LOGGER.info(
-                "Image built and available under following tags: {}".format(
-                    ", ".join(tags)
-                )
-            )
-        except Exception:
-            raise CekitError("Image build failed, see logs above.")
+        LOGGER.info(
+            "Image built and available under following tags: {}".format(", ".join(tags))
+        )

--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -2,13 +2,12 @@ import json
 import logging
 import os
 import shutil
-import subprocess
 
 from cekit.config import Config
 from cekit.crypto import SUPPORTED_HASH_ALGORITHMS, check_sum
 from cekit.descriptor import Descriptor
 from cekit.errors import CekitError
-from cekit.tools import Chdir, Map, download_file, get_brew_url
+from cekit.tools import Chdir, Map, download_file, get_brew_url, run_wrapper
 
 logger = logging.getLogger("cekit")
 config = Config()
@@ -472,15 +471,11 @@ class _GitResource(Resource):
 
     def _copy_impl(self, target):
         cmd = ["git", "clone", self.git.url, target]
-        logger.debug("Cloning Git repository: '{}'".format(" ".join(cmd)))
-        subprocess.check_output(cmd)
+        run_wrapper(cmd, False, f"Could not clone from {self.git.url}")
 
         with Chdir(target):
             cmd = ["git", "checkout", self.git.ref]
-            logger.debug(
-                "Checking out '{}' ref: '{}'".format(self.git.ref, " ".join(cmd))
-            )
-            subprocess.check_output(cmd)
+            run_wrapper(cmd, False, f"Could not checkout from {self.git.ref}")
 
         return target
 

--- a/cekit/test/collector.py
+++ b/cekit/test/collector.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import shutil
-import subprocess
 import sys
+
+from cekit.tools import run_wrapper
 
 logger = logging.getLogger("cekit")
 
@@ -51,8 +52,7 @@ class BehaveTestCollector(object):
             "-b",
             "v%s" % version,
         ]
-        logger.debug("Running '{}'".format(" ".join(cmd)))
-        subprocess.check_output(cmd)
+        run_wrapper(cmd, False, f"Could not fetch steps from {url}")
 
     def collect(self, version, url):
         # first clone common steps

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -346,6 +346,8 @@ def run_wrapper(
             )
         )
         raise CekitError(exception_message, ex)
+    if result.stdout:
+        result.stdout = result.stdout.strip()
     return result
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -202,12 +202,17 @@ def test_osbs_builder_run_brew_stage(mocker):
         [
             call(
                 ["git", "config", "--get", "remote.origin.url"],
-                capture_output=True,
+                stderr=-1,
+                stdout=-1,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
-                ["git", "rev-parse", "HEAD"], capture_output=True, check=True, text=True
+                ["git", "rev-parse", "HEAD"],
+                stderr=-1,
+                stdout=-1,
+                check=True,
+                universal_newlines=True,
             ),
             call(
                 [
@@ -218,9 +223,10 @@ def test_osbs_builder_run_brew_stage(mocker):
                     "--kwargs",
                     "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
                 ],
-                capture_output=True,
+                stderr=-1,
+                stdout=-1,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ]
     )
@@ -255,12 +261,17 @@ def test_osbs_builder_run_brew(mocker):
         [
             call(
                 ["git", "config", "--get", "remote.origin.url"],
-                capture_output=True,
+                stderr=-1,
+                stdout=-1,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
-                ["git", "rev-parse", "HEAD"], capture_output=True, check=True, text=True
+                ["git", "rev-parse", "HEAD"],
+                stderr=-1,
+                stdout=-1,
+                check=True,
+                universal_newlines=True,
             ),
             call(
                 [
@@ -271,9 +282,10 @@ def test_osbs_builder_run_brew(mocker):
                     "--kwargs",
                     "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
                 ],
-                capture_output=True,
+                stderr=-1,
+                stdout=-1,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ]
     )
@@ -308,12 +320,17 @@ def test_osbs_builder_run_koji(mocker):
         [
             call(
                 ["git", "config", "--get", "remote.origin.url"],
-                capture_output=True,
+                stderr=-1,
+                stdout=-1,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
-                ["git", "rev-parse", "HEAD"], capture_output=True, check=True, text=True
+                ["git", "rev-parse", "HEAD"],
+                stderr=-1,
+                stdout=-1,
+                check=True,
+                universal_newlines=True,
             ),
             call(
                 [
@@ -324,9 +341,10 @@ def test_osbs_builder_run_koji(mocker):
                     "--kwargs",
                     "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
                 ],
-                capture_output=True,
+                stderr=-1,
+                stdout=-1,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ]
     )
@@ -395,9 +413,10 @@ def test_osbs_builder_run_brew_user(mocker):
             "--kwargs",
             "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
         ],
-        capture_output=True,
+        stderr=-1,
+        stdout=-1,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -435,9 +454,10 @@ def test_osbs_builder_run_brew_target_defined_in_descriptor(mocker):
             "--kwargs",
             "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-target', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
         ],
-        capture_output=True,
+        stderr=-1,
+        stdout=-1,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -472,9 +492,10 @@ def test_osbs_wait_for_osbs_task_finished_successfully(mocker):
 
     run.assert_called_with(
         ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"],
-        capture_output=True,
+        stderr=-1,
+        stdout=-1,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
     sleep.assert_not_called()
 
@@ -527,15 +548,17 @@ def test_osbs_wait_for_osbs_task_in_progress(mocker):
         [
             call(
                 ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"],
-                capture_output=True,
+                stderr=-1,
+                stdout=-1,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"],
-                capture_output=True,
+                stderr=-1,
+                stdout=-1,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ]
     )
@@ -577,9 +600,10 @@ def test_osbs_wait_for_osbs_task_failed(mocker):
 
     run.assert_called_with(
         ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"],
-        capture_output=True,
+        stderr=-1,
+        stdout=-1,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
     sleep.assert_not_called()
 
@@ -858,9 +882,10 @@ def test_buildah_builder_run(mocker):
             "bar",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -883,9 +908,10 @@ def test_buildah_builder_run_platform(mocker):
             "bar",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -907,9 +933,10 @@ def test_buildah_builder_run_pull(mocker):
             "bar",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -930,9 +957,10 @@ def test_podman_builder_run(mocker):
             "bar",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -954,9 +982,10 @@ def test_podman_builder_run_pull(mocker):
             "bar",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -984,9 +1013,10 @@ def test_podman_builder_run_platform(mocker):
             "bar",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -1025,9 +1055,10 @@ def test_podman_builder_run_with_generator(mocker):
             "foo:latest",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -1066,9 +1097,10 @@ def test_buildah_builder_run_with_generator(mocker):
             "foo:latest",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -1088,9 +1120,10 @@ def test_buildah_builder_with_squashing_disabled(mocker):
             "bar",
             "something/image",
         ],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 
@@ -1102,9 +1135,10 @@ def test_podman_builder_with_squashing_disabled(mocker):
 
     run.assert_called_once_with(
         ["/usr/bin/podman", "build", "-t", "foo", "-t", "bar", "something/image"],
-        capture_output=False,
+        stderr=None,
+        stdout=None,
         check=True,
-        text=True,
+        universal_newlines=True,
     )
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -31,7 +31,7 @@ config = Config()
 
 
 def test_osbs_builder_defaults(mocker):
-    mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(subprocess, "run")
 
     builder = create_builder_object(mocker, "osbs", {})
 
@@ -42,7 +42,7 @@ def test_osbs_builder_defaults(mocker):
 
 def test_osbs_builder_redhat(mocker):
     config.cfg["common"] = {"redhat": True}
-    mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(subprocess, "run")
 
     builder = create_builder_object(mocker, "osbs", {})
 
@@ -53,7 +53,7 @@ def test_osbs_builder_redhat(mocker):
 
 def test_osbs_builder_use_rhpkg_stage(mocker):
     config.cfg["common"] = {"redhat": True}
-    mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(subprocess, "run")
 
     builder = create_builder_object(mocker, "osbs", {"stage": True})
 
@@ -63,7 +63,7 @@ def test_osbs_builder_use_rhpkg_stage(mocker):
 
 
 def test_osbs_builder_custom_commit_msg(mocker):
-    mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(subprocess, "run")
 
     builder = create_builder_object(
         mocker, "osbs", {"stage": True, "commit_message": "foo"}
@@ -73,7 +73,7 @@ def test_osbs_builder_custom_commit_msg(mocker):
 
 
 def test_osbs_builder_nowait(mocker):
-    mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(subprocess, "run")
 
     builder = create_builder_object(mocker, "osbs", {"nowait": True})
 
@@ -81,7 +81,7 @@ def test_osbs_builder_nowait(mocker):
 
 
 def test_osbs_builder_user(mocker):
-    mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(subprocess, "run")
 
     builder = create_builder_object(mocker, "osbs", {"user": "UserFoo"})
     assert builder.params.user == "UserFoo"
@@ -89,7 +89,7 @@ def test_osbs_builder_user(mocker):
 
 def test_merge_container_yaml_no_limit_arch(mocker, tmpdir):
     mocker.patch.object(glob, "glob", return_value=False)
-    mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(subprocess, "run")
 
     builder = create_builder_object(mocker, "osbs", {})
     builder.dist_git_dir = str(tmpdir.mkdir("target"))
@@ -112,7 +112,7 @@ def test_merge_container_yaml_no_limit_arch(mocker, tmpdir):
 
 def test_merge_container_yaml_limit_arch(mocker, tmpdir):
     mocker.patch.object(glob, "glob", return_value=True)
-    mocker.patch.object(subprocess, "check_output")
+    mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "osbs", {})
     builder.dist_git_dir = str(tmpdir.mkdir("target"))
 
@@ -178,14 +178,18 @@ def test_osbs_builder_run_brew_stage(mocker):
     config.cfg["common"] = {"redhat": True}
     params = {"stage": True}
 
-    check_output = mocker.patch.object(
+    run = mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         autospec=True,
         side_effect=[
-            b"ssh://user:password@something.redhat.com/containers/openjdk",
-            b"c5a0731b558c8a247dd7f85b5f54462cd5b68b23",
-            b"12345",
+            subprocess.CompletedProcess(
+                "", 0, "ssh://user:password@something.redhat.com/containers/openjdk"
+            ),
+            subprocess.CompletedProcess(
+                "", 0, "c5a0731b558c8a247dd7f85b5f54462cd5b68b23"
+            ),
+            subprocess.CompletedProcess("", 0, "12345"),
         ],
     )
     builder = create_builder_object(mocker, "osbs", params)
@@ -194,10 +198,17 @@ def test_osbs_builder_run_brew_stage(mocker):
     builder.dist_git.branch = "some-branch"
     builder.run()
 
-    check_output.assert_has_calls(
+    run.assert_has_calls(
         [
-            call(["git", "config", "--get", "remote.origin.url"]),
-            call(["git", "rev-parse", "HEAD"]),
+            call(
+                ["git", "config", "--get", "remote.origin.url"],
+                capture_output=True,
+                check=True,
+                text=True,
+            ),
+            call(
+                ["git", "rev-parse", "HEAD"], capture_output=True, check=True, text=True
+            ),
             call(
                 [
                     "/usr/bin/brew-stage",
@@ -206,7 +217,10 @@ def test_osbs_builder_run_brew_stage(mocker):
                     "buildContainer",
                     "--kwargs",
                     "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
-                ]
+                ],
+                capture_output=True,
+                check=True,
+                text=True,
             ),
         ]
     )
@@ -217,14 +231,18 @@ def test_osbs_builder_run_brew_stage(mocker):
 def test_osbs_builder_run_brew(mocker):
     config.cfg["common"] = {"redhat": True}
 
-    check_output = mocker.patch.object(
+    run = mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         autospec=True,
         side_effect=[
-            b"ssh://user:password@something.redhat.com/containers/openjdk",
-            b"c5a0731b558c8a247dd7f85b5f54462cd5b68b23",
-            b"12345",
+            subprocess.CompletedProcess(
+                "", 0, "ssh://user:password@something.redhat.com/containers/openjdk"
+            ),
+            subprocess.CompletedProcess(
+                "", 0, "c5a0731b558c8a247dd7f85b5f54462cd5b68b23"
+            ),
+            subprocess.CompletedProcess("", 0, "12345"),
         ],
     )
     builder = create_builder_object(mocker, "osbs", {})
@@ -233,10 +251,17 @@ def test_osbs_builder_run_brew(mocker):
     builder.dist_git.branch = "some-branch"
     builder.run()
 
-    check_output.assert_has_calls(
+    run.assert_has_calls(
         [
-            call(["git", "config", "--get", "remote.origin.url"]),
-            call(["git", "rev-parse", "HEAD"]),
+            call(
+                ["git", "config", "--get", "remote.origin.url"],
+                capture_output=True,
+                check=True,
+                text=True,
+            ),
+            call(
+                ["git", "rev-parse", "HEAD"], capture_output=True, check=True, text=True
+            ),
             call(
                 [
                     "/usr/bin/brew",
@@ -245,7 +270,10 @@ def test_osbs_builder_run_brew(mocker):
                     "buildContainer",
                     "--kwargs",
                     "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
-                ]
+                ],
+                capture_output=True,
+                check=True,
+                text=True,
             ),
         ]
     )
@@ -254,14 +282,18 @@ def test_osbs_builder_run_brew(mocker):
 
 
 def test_osbs_builder_run_koji(mocker):
-    check_output = mocker.patch.object(
+    run = mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         autospec=True,
         side_effect=[
-            b"ssh://user:password@something.redhat.com/containers/openjdk",
-            b"c5a0731b558c8a247dd7f85b5f54462cd5b68b23",
-            b"12345",
+            subprocess.CompletedProcess(
+                "", 0, "ssh://user:password@something.redhat.com/containers/openjdk"
+            ),
+            subprocess.CompletedProcess(
+                "", 0, "c5a0731b558c8a247dd7f85b5f54462cd5b68b23"
+            ),
+            subprocess.CompletedProcess("", 0, "12345"),
         ],
     )
     builder = create_builder_object(
@@ -272,10 +304,17 @@ def test_osbs_builder_run_koji(mocker):
     builder.dist_git.branch = "some-branch"
     builder.run()
 
-    check_output.assert_has_calls(
+    run.assert_has_calls(
         [
-            call(["git", "config", "--get", "remote.origin.url"]),
-            call(["git", "rev-parse", "HEAD"]),
+            call(
+                ["git", "config", "--get", "remote.origin.url"],
+                capture_output=True,
+                check=True,
+                text=True,
+            ),
+            call(
+                ["git", "rev-parse", "HEAD"], capture_output=True, check=True, text=True
+            ),
             call(
                 [
                     "/usr/bin/koji",
@@ -284,7 +323,10 @@ def test_osbs_builder_run_koji(mocker):
                     "buildContainer",
                     "--kwargs",
                     "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
-                ]
+                ],
+                capture_output=True,
+                check=True,
+                text=True,
             ),
         ]
     )
@@ -297,12 +339,16 @@ def test_osbs_builder_run_brew_nowait(mocker):
 
     mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         autospec=True,
         side_effect=[
-            b"ssh://user:password@something.redhat.com/containers/openjdk",
-            b"c5a0731b558c8a247dd7f85b5f54462cd5b68b23",
-            b"12345",
+            subprocess.CompletedProcess(
+                "", 0, "ssh://user:password@something.redhat.com/containers/openjdk"
+            ),
+            subprocess.CompletedProcess(
+                "", 0, "c5a0731b558c8a247dd7f85b5f54462cd5b68b23"
+            ),
+            subprocess.CompletedProcess("", 0, "12345"),
         ],
     )
     builder = create_builder_object(mocker, "osbs", params)
@@ -318,14 +364,18 @@ def test_osbs_builder_run_brew_user(mocker):
     config.cfg["common"] = {"redhat": True}
     params = {"user": "Foo"}
 
-    check_output = mocker.patch.object(
+    run = mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         autospec=True,
         side_effect=[
-            b"ssh://user:password@something.redhat.com/containers/openjdk",
-            b"c5a0731b558c8a247dd7f85b5f54462cd5b68b23",
-            b"12345",
+            subprocess.CompletedProcess(
+                "", 0, "ssh://user:password@something.redhat.com/containers/openjdk"
+            ),
+            subprocess.CompletedProcess(
+                "", 0, "c5a0731b558c8a247dd7f85b5f54462cd5b68b23"
+            ),
+            subprocess.CompletedProcess("", 0, "12345"),
         ],
     )
     builder = create_builder_object(mocker, "osbs", params)
@@ -334,7 +384,7 @@ def test_osbs_builder_run_brew_user(mocker):
     builder.dist_git.branch = "some-branch"
     builder.run()
 
-    check_output.assert_called_with(
+    run.assert_called_with(
         [
             "/usr/bin/brew",
             "--user",
@@ -344,21 +394,28 @@ def test_osbs_builder_run_brew_user(mocker):
             "buildContainer",
             "--kwargs",
             "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
-        ]
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
     )
 
 
 def test_osbs_builder_run_brew_target_defined_in_descriptor(mocker):
     config.cfg["common"] = {"redhat": True}
 
-    check_output = mocker.patch.object(
+    run = mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         autospec=True,
         side_effect=[
-            b"ssh://user:password@something.redhat.com/containers/openjdk",
-            b"c5a0731b558c8a247dd7f85b5f54462cd5b68b23",
-            b"12345",
+            subprocess.CompletedProcess(
+                "", 0, "ssh://user:password@something.redhat.com/containers/openjdk"
+            ),
+            subprocess.CompletedProcess(
+                "", 0, "c5a0731b558c8a247dd7f85b5f54462cd5b68b23"
+            ),
+            subprocess.CompletedProcess("", 0, "12345"),
         ],
     )
     builder = create_builder_object(mocker, "osbs", {})
@@ -369,7 +426,7 @@ def test_osbs_builder_run_brew_target_defined_in_descriptor(mocker):
     builder.dist_git.branch = "some-branch"
     builder.run()
 
-    check_output.assert_called_with(
+    run.assert_called_with(
         [
             "/usr/bin/brew",
             "call",
@@ -377,7 +434,10 @@ def test_osbs_builder_run_brew_target_defined_in_descriptor(mocker):
             "buildContainer",
             "--kwargs",
             "{'src': 'git://something.redhat.com/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-target', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
-        ]
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
     )
 
 
@@ -386,11 +446,14 @@ def test_osbs_wait_for_osbs_task_finished_successfully(mocker):
     builder = create_builder_object(mocker, "osbs", {})
 
     sleep = mocker.patch.object(time, "sleep")
-    check_output = mocker.patch.object(
+    run = mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         side_effect=[
-            b"""{
+            subprocess.CompletedProcess(
+                "",
+                0,
+                """{
             "state": 2,
             "create_time": "2019-02-15 13:14:58.278557",
             "create_ts": 1550236498.27856,
@@ -400,14 +463,18 @@ def test_osbs_wait_for_osbs_task_finished_successfully(mocker):
             "completion_ts": 1550237431.0166,
             "arch": "noarch",
             "id": 20222655
-        }"""
+        }""",
+            )
         ],
     )
 
     assert builder._wait_for_osbs_task("12345") is True
 
-    check_output.assert_called_with(
-        ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"]
+    run.assert_called_with(
+        ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"],
+        capture_output=True,
+        check=True,
+        text=True,
     )
     sleep.assert_not_called()
 
@@ -417,11 +484,14 @@ def test_osbs_wait_for_osbs_task_in_progress(mocker):
     builder = create_builder_object(mocker, "osbs", {})
 
     sleep = mocker.patch.object(time, "sleep")
-    check_output = mocker.patch.object(
+    run = mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         side_effect=[
-            b"""{
+            subprocess.CompletedProcess(
+                "",
+                0,
+                """{
             "state": 1,
             "create_time": "2019-02-15 13:14:58.278557",
             "create_ts": 1550236498.27856,
@@ -432,7 +502,11 @@ def test_osbs_wait_for_osbs_task_in_progress(mocker):
             "arch": "noarch",
             "id": 20222655
         }""",
-            b"""{
+            ),
+            subprocess.CompletedProcess(
+                "",
+                0,
+                """{
             "state": 2,
             "create_time": "2019-02-15 13:14:58.278557",
             "create_ts": 1550236498.27856,
@@ -443,15 +517,26 @@ def test_osbs_wait_for_osbs_task_in_progress(mocker):
             "arch": "noarch",
             "id": 20222655
         }""",
+            ),
         ],
     )
 
     assert builder._wait_for_osbs_task("12345") is True
 
-    check_output.assert_has_calls(
+    run.assert_has_calls(
         [
-            call(["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"]),
-            call(["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"]),
+            call(
+                ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"],
+                capture_output=True,
+                check=True,
+                text=True,
+            ),
+            call(
+                ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"],
+                capture_output=True,
+                check=True,
+                text=True,
+            ),
         ]
     )
     sleep.assert_called_once_with(20)
@@ -462,11 +547,14 @@ def test_osbs_wait_for_osbs_task_failed(mocker):
     builder = create_builder_object(mocker, "osbs", {})
 
     sleep = mocker.patch.object(time, "sleep")
-    check_output = mocker.patch.object(
+    run = mocker.patch.object(
         subprocess,
-        "check_output",
+        "run",
         side_effect=[
-            b"""{
+            subprocess.CompletedProcess(
+                "",
+                0,
+                """{
             "state": 5,
             "create_time": "2019-02-15 13:14:58.278557",
             "create_ts": 1550236498.27856,
@@ -476,7 +564,8 @@ def test_osbs_wait_for_osbs_task_failed(mocker):
             "completion_ts": 1550237431.0166,
             "arch": "noarch",
             "id": 20222655
-        }"""
+        }""",
+            )
         ],
     )
 
@@ -486,8 +575,11 @@ def test_osbs_wait_for_osbs_task_failed(mocker):
     ):
         builder._wait_for_osbs_task("12345")
 
-    check_output.assert_called_with(
-        ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"]
+    run.assert_called_with(
+        ["/usr/bin/brew", "call", "--json-output", "getTaskInfo", "12345"],
+        capture_output=True,
+        check=True,
+        text=True,
     )
     sleep.assert_not_called()
 
@@ -751,11 +843,11 @@ def test_docker_squashing_parameters(mocker):
 
 def test_buildah_builder_run(mocker):
     params = {"tags": ["foo", "bar"]}
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "buildah", params)
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/buildah",
             "build-using-dockerfile",
@@ -765,17 +857,20 @@ def test_buildah_builder_run(mocker):
             "-t",
             "bar",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
 def test_buildah_builder_run_platform(mocker):
     params = {"tags": ["foo", "bar"], "platform": "linux/amd64,linux/arm64"}
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "buildah", params)
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/buildah",
             "build-using-dockerfile",
@@ -787,17 +882,20 @@ def test_buildah_builder_run_platform(mocker):
             "-t",
             "bar",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
 def test_buildah_builder_run_pull(mocker):
     params = {"tags": ["foo", "bar"], "pull": True}
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "buildah", params)
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/buildah",
             "build-using-dockerfile",
@@ -808,17 +906,20 @@ def test_buildah_builder_run_pull(mocker):
             "-t",
             "bar",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
 def test_podman_builder_run(mocker):
     params = {"tags": ["foo", "bar"]}
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/podman",
             "build",
@@ -828,17 +929,20 @@ def test_podman_builder_run(mocker):
             "-t",
             "bar",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
 def test_podman_builder_run_pull(mocker):
     params = {"tags": ["foo", "bar"], "pull": True}
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/podman",
             "build",
@@ -849,7 +953,10 @@ def test_podman_builder_run_pull(mocker):
             "-t",
             "bar",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
@@ -859,11 +966,11 @@ def test_podman_builder_run_platform(mocker):
         "pull": True,
         "platform": "linux/amd64,linux/arm64",
     }
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/podman",
             "build",
@@ -876,13 +983,16 @@ def test_podman_builder_run_platform(mocker):
             "-t",
             "bar",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
 def test_podman_builder_run_with_generator(mocker):
     params = Map({"tags": []})
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
     builder.generator = DockerGenerator("", "", {})
     builder.generator.image = Image(
@@ -904,7 +1014,7 @@ def test_podman_builder_run_with_generator(mocker):
     )
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/podman",
             "build",
@@ -914,13 +1024,16 @@ def test_podman_builder_run_with_generator(mocker):
             "-t",
             "foo:latest",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
 def test_buildah_builder_run_with_generator(mocker):
     params = Map({"tags": []})
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "buildah", params)
     builder.generator = DockerGenerator("", "", {})
     builder.generator.image = Image(
@@ -942,7 +1055,7 @@ def test_buildah_builder_run_with_generator(mocker):
     )
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/buildah",
             "build-using-dockerfile",
@@ -952,17 +1065,20 @@ def test_buildah_builder_run_with_generator(mocker):
             "-t",
             "foo:latest",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
 def test_buildah_builder_with_squashing_disabled(mocker):
     params = {"tags": ["foo", "bar"], "no_squash": True}
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "buildah", params)
     builder.run()
 
-    check_call.assert_called_once_with(
+    run.assert_called_once_with(
         [
             "/usr/bin/buildah",
             "build-using-dockerfile",
@@ -971,18 +1087,24 @@ def test_buildah_builder_with_squashing_disabled(mocker):
             "-t",
             "bar",
             "something/image",
-        ]
+        ],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 
 def test_podman_builder_with_squashing_disabled(mocker):
     params = {"tags": ["foo", "bar"], "no_squash": True}
-    check_call = mocker.patch.object(subprocess, "check_call")
+    run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
     builder.run()
 
-    check_call.assert_called_once_with(
-        ["/usr/bin/podman", "build", "-t", "foo", "-t", "bar", "something/image"]
+    run.assert_called_once_with(
+        ["/usr/bin/podman", "build", "-t", "foo", "-t", "bar", "something/image"],
+        capture_output=False,
+        check=True,
+        text=True,
     )
 
 

--- a/tests/test_integ_builder_osbs.py
+++ b/tests/test_integ_builder_osbs.py
@@ -195,15 +195,17 @@ def test_osbs_builder_with_assume_yes(tmpdir, mocker, caplog):
         [
             call(
                 ["git", "add", "--all", "Dockerfile"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 ["git", "push", "-q", "origin", "branch"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 [
@@ -213,9 +215,10 @@ def test_osbs_builder_with_assume_yes(tmpdir, mocker, caplog):
                     "-m",
                     "Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb",
                 ],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ],
         any_order=True,
@@ -278,15 +281,17 @@ def test_osbs_builder_with_push_with_sync_only(tmpdir, mocker, caplog):
         [
             mocker.call(
                 ["git", "add", "--all", "Dockerfile"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 ["git", "push", "-q", "origin", "branch"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             mocker.call(
                 [
@@ -296,9 +301,10 @@ def test_osbs_builder_with_push_with_sync_only(tmpdir, mocker, caplog):
                     "-m",
                     "Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb",
                 ],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ],
         any_order=True,
@@ -339,9 +345,10 @@ def test_osbs_builder_kick_build_without_push(tmpdir, mocker, caplog):
         [
             mocker.call(
                 ["git", "add", "--all", "Dockerfile"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             )
         ]
     )
@@ -373,15 +380,17 @@ def test_osbs_builder_kick_build_with_push(tmpdir, mocker, caplog):
         [
             mocker.call(
                 ["git", "add", "--all", "Dockerfile"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             mocker.call(
                 ["git", "push", "-q", "origin", "branch"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             mocker.call(
                 [
@@ -391,9 +400,10 @@ def test_osbs_builder_kick_build_with_push(tmpdir, mocker, caplog):
                     "-m",
                     "Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb",
                 ],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ],
         any_order=True,
@@ -433,15 +443,17 @@ def test_osbs_builder_add_help_file(tmpdir, mocker, caplog):
         [
             mocker.call(
                 ["git", "add", "--all", "Dockerfile"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             mocker.call(
                 ["git", "add", "--all", "help.md"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ]
     )
@@ -480,18 +492,20 @@ def test_osbs_builder_add_extra_files(tmpdir, mocker, caplog):
     assert (
         call(
             ["git", "add", "--all", "Dockerfile"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
     assert (
         call(
             ["git", "add", "--all", "osbs_extra"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
@@ -556,27 +570,30 @@ def test_osbs_builder_add_extra_files_with_extra_dir_target(tmpdir, mocker, capl
     assert (
         mocker.call(
             ["git", "rm", "-rf", "osbs_extra"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
     assert (
         mocker.call(
             ["git", "add", "--all", "osbs_extra"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
     assert (
         mocker.call(
             ["git", "add", "--all", "osbs_extra"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
@@ -655,25 +672,31 @@ def test_osbs_builder_add_extra_files_non_default_with_extra_dir_target(
 
     assert (
         mocker.call(
-            ["git", "rm", "-rf", "foobar"], capture_output=False, check=True, text=True
+            ["git", "rm", "-rf", "foobar"],
+            stderr=None,
+            stdout=None,
+            check=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
     assert (
         mocker.call(
             ["git", "add", "--all", "foobar"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
     assert (
         mocker.call(
             ["git", "add", "--all", "Dockerfile"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
@@ -732,27 +755,30 @@ def test_osbs_builder_add_extra_files_and_overwrite(tmpdir, mocker, caplog):
     assert (
         mocker.call(
             ["git", "rm", "-rf", "osbs_extra"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
     assert (
         mocker.call(
             ["git", "add", "--all", "osbs_extra"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
     assert (
         mocker.call(
             ["git", "add", "--all", "Dockerfile"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
@@ -803,16 +829,21 @@ def test_osbs_builder_add_extra_files_from_custom_dir(tmpdir, mocker, caplog):
 
     assert (
         mocker.call(
-            ["git", "add", "--all", "dist"], capture_output=False, check=True, text=True
+            ["git", "add", "--all", "dist"],
+            stderr=None,
+            stdout=None,
+            check=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
     assert (
         mocker.call(
             ["git", "add", "--all", "Dockerfile"],
-            capture_output=False,
+            stderr=None,
+            stdout=None,
             check=True,
-            text=True,
+            universal_newlines=True,
         )
         in mock_run.mock_calls
     )
@@ -890,21 +921,24 @@ def test_osbs_builder_add_files_to_dist_git_when_it_is_a_directory(
         [
             mocker.call(
                 ["git", "add", "--all", "manifests"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             mocker.call(
                 ["git", "add", "--all", "Dockerfile"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 ["git", "push", "-q", "origin", "branch"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 [
@@ -914,9 +948,10 @@ def test_osbs_builder_add_files_to_dist_git_when_it_is_a_directory(
                     "-m",
                     "Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb",
                 ],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ],
         any_order=True,
@@ -961,21 +996,24 @@ def test_osbs_builder_add_artifact_directory_to_dist_git_when_it_already_exists(
         [
             mocker.call(
                 ["git", "add", "--all", "manifests"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             mocker.call(
                 ["git", "add", "--all", "Dockerfile"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 ["git", "push", "-q", "origin", "branch"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 [
@@ -985,9 +1023,10 @@ def test_osbs_builder_add_artifact_directory_to_dist_git_when_it_already_exists(
                     "-m",
                     "Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb",
                 ],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ],
         any_order=True,
@@ -1028,21 +1067,24 @@ def test_osbs_builder_add_files_to_dist_git_without_dotgit_directory(
         [
             mocker.call(
                 ["git", "add", "--all", "fetch-artifacts-url.yaml"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             mocker.call(
                 ["git", "add", "--all", "Dockerfile"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 ["git", "push", "-q", "origin", "branch"],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             mocker.call(
                 [
@@ -1052,9 +1094,10 @@ def test_osbs_builder_add_files_to_dist_git_without_dotgit_directory(
                     "-m",
                     "Sync with path, commit 3b9283cb26b35511517ff5c0c3e11f490cba8feb",
                 ],
-                capture_output=False,
+                stderr=None,
+                stdout=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
         ],
         any_order=True,

--- a/tests/test_unit_resource.py
+++ b/tests/test_unit_resource.py
@@ -25,7 +25,7 @@ def setup_function(function):
 
 
 def test_repository_dir_is_constructed_properly(mocker):
-    mocker.patch("subprocess.check_output")
+    mocker.patch("subprocess.run")
     mocker.patch("os.path.isdir", ret="True")
     mocker.patch("cekit.descriptor.resource.Chdir", autospec=True)
 
@@ -37,7 +37,7 @@ def test_repository_dir_is_constructed_properly(mocker):
 
 
 def test_repository_dir_uses_name_if_defined(mocker):
-    mocker.patch("subprocess.check_output")
+    mocker.patch("subprocess.run")
     mocker.patch("os.path.isdir", ret="True")
     mocker.patch("cekit.descriptor.resource.Chdir", autospec=True)
 
@@ -51,7 +51,7 @@ def test_repository_dir_uses_name_if_defined(mocker):
 
 
 def test_repository_dir_uses_target_if_defined(mocker):
-    mocker.patch("subprocess.check_output")
+    mocker.patch("subprocess.run")
     mocker.patch("os.path.isdir", ret="True")
     mocker.patch("cekit.descriptor.resource.Chdir", autospec=True)
 
@@ -65,7 +65,7 @@ def test_repository_dir_uses_target_if_defined(mocker):
 
 
 def test_git_clone(mocker):
-    mock = mocker.patch("subprocess.check_output")
+    mock = mocker.patch("subprocess.run")
     mocker.patch("os.path.isdir", ret="True")
     mocker.patch("cekit.descriptor.resource.Chdir", autospec=True)
 
@@ -75,8 +75,18 @@ def test_git_clone(mocker):
     res.copy("dir")
     mock.assert_has_calls(
         [
-            call(["git", "clone", "http://host.com/url/path.git", "dir/path"]),
-            call(["git", "checkout", "ref"]),
+            call(
+                ["git", "clone", "http://host.com/url/path.git", "dir/path"],
+                capture_output=False,
+                check=True,
+                text=True,
+            ),
+            call(
+                ["git", "checkout", "ref"],
+                capture_output=False,
+                check=True,
+                text=True,
+            ),
         ]
     )
 

--- a/tests/test_unit_resource.py
+++ b/tests/test_unit_resource.py
@@ -77,17 +77,20 @@ def test_git_clone(mocker):
         [
             call(
                 ["git", "clone", "http://host.com/url/path.git", "dir/path"],
-                capture_output=False,
+                stdout=None,
+                stderr=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
             call(
                 ["git", "checkout", "ref"],
-                capture_output=False,
+                stdout=None,
+                stderr=None,
                 check=True,
-                text=True,
+                universal_newlines=True,
             ),
-        ]
+        ],
+        any_order=True,
     )
 
 

--- a/tests/test_unit_tools.py
+++ b/tests/test_unit_tools.py
@@ -13,7 +13,7 @@ from cekit import tools
 from cekit.descriptor import Descriptor, Image, Module, Osbs, Overrides, Run
 from cekit.descriptor.base import _merge_descriptors, _merge_lists
 from cekit.errors import CekitError
-from cekit.tools import run_wrapper
+from cekit.tools import Chdir, run_wrapper
 
 rhel_7_os_release = '''NAME="Red Hat Enterprise Linux Server"
 VERSION="7.7 (Maipo)"
@@ -861,3 +861,17 @@ def test_run_wrapper_no_capture() -> None:
     result = run_wrapper(["git", "rev-parse", "--is-inside-work-tree"], False)
     assert result.stdout is None
     assert result.returncode == 0
+
+
+def test_run_wrapper_capture_error(tmpdir) -> None:
+    with Chdir(str(tmpdir)):
+        # Under tox, the tmpdir is inside the cloned CEKit so create a fake
+        # file to break git.
+        with open(".git", "w") as f:
+            f.write("break git")
+        result = run_wrapper(
+            ["git", "rev-parse", "--is-inside-work-tree"], True, check=False
+        )
+        assert result.stdout == ""
+        assert not result.stderr.endswith("\n")
+        assert result.returncode == 128

--- a/tests/test_unit_tools.py
+++ b/tests/test_unit_tools.py
@@ -13,6 +13,7 @@ from cekit import tools
 from cekit.descriptor import Descriptor, Image, Module, Osbs, Overrides, Run
 from cekit.descriptor.base import _merge_descriptors, _merge_lists
 from cekit.errors import CekitError
+from cekit.tools import run_wrapper
 
 rhel_7_os_release = '''NAME="Red Hat Enterprise Linux Server"
 VERSION="7.7 (Maipo)"
@@ -848,3 +849,15 @@ def test_handle_core_dependencies_with_certifi(mocker, caplog):
         in caplog.text
     )
     assert "Certificate Authority (CA) bundle in use: 'a/path.pem'" in caplog.text
+
+
+def test_run_wrapper_whitespace() -> None:
+    result = run_wrapper(["git", "rev-parse", "--is-inside-work-tree"], True)
+    assert result.stdout == "true"
+    assert result.returncode == 0
+
+
+def test_run_wrapper_no_capture() -> None:
+    result = run_wrapper(["git", "rev-parse", "--is-inside-work-tree"], False)
+    assert result.stdout is None
+    assert result.returncode == 0

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import shutil
-import subprocess
 import sys
 import uuid
 
@@ -71,7 +70,6 @@ Feature: Test test
 
 
 def run_cekit_cs_overrides(image_dir, mocker, overrides_descriptor):
-    mocker.patch.object(subprocess, "check_output", return_value=odcs_fake_resp)
     mocker.patch.object(Repository, "fetch")
 
     copy_repos(image_dir)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py3.10
+envlist = py36,py37,py38,py39,py3.10
 
 [testenv]
 deps=pipenv


### PR DESCRIPTION
…d typing.


The reason to switch to `subprocess.run` (https://docs.python.org/3/library/subprocess.html) is: 
> The recommended approach to invoking subprocesses is to use the [run()](https://docs.python.org/3/library/subprocess.html#subprocess.run) function for all use cases it can handle.