### PR TITLE
Revert changes for module processing order.

### DIFF
--- a/cekit/descriptor/image.py
+++ b/cekit/descriptor/image.py
@@ -388,6 +388,7 @@ class Image(Descriptor):
         self.packages._descriptor["repositories"] = list(
             self._package_repositories.values()
         )
+
         # final 'run' value
         if self.run:
             self.run = self.run.merge(self._module_run)
@@ -396,7 +397,7 @@ class Image(Descriptor):
 
     def process_install_list(
         self, source, to_install_list, install_list, module_registry
-    ):
+    ) -> None:
         module_overrides = self._image_overrides["modules"]
         artifact_overrides = self._image_overrides["artifacts"]
         for to_install in to_install_list:
@@ -456,6 +457,13 @@ class Image(Descriptor):
                 name = repo.name
                 if name not in self._package_repositories:
                     self._package_repositories[name] = repo
+
+            # collect package manager
+            if not self.packages.manager and module.packages.manager:
+                logger.debug(
+                    f"Applying module package manager of {module.packages.manager} to image"
+                )
+                self.packages._descriptor["manager"] = module.packages.manager
 
             # incorporate run specification contributed by module
             if module.run:

--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -184,10 +184,10 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
     {% endfor %}
     {% endif %}
 
-{{ process_module(animage) }}
     {% for to_install in animage.modules.install %}
 {{ process_module(helper.module(to_install), animage) }}
     {% endfor %}
+{{ process_module(animage) }}
     {%if helper.cachito(animage) %}
     RUN rm -rf $REMOTE_SOURCE_DIR
     {% endif %}

--- a/docs/descriptor/includes/packages/manager.rst
+++ b/docs/descriptor/includes/packages/manager.rst
@@ -15,6 +15,10 @@ Currently available options are ``yum``, ``dnf``, ``microdnf``, ``apt-get`` and 
     If you do not specify this key the default value is ``yum``.
     If your image requires different package manager you need to specify it.
 
+    It is only possible to define a single package manager for an image (although multi-stage images may have
+    different package managers). A package manager may be defined in a module or in an image (the latter takes
+    precedence).
+
     The default ``yum`` value will work fine on Fedora and RHEL images because
     OS maintains a symlink to the proper package manager.
 

--- a/docs/handbook/modules/image_order.rst
+++ b/docs/handbook/modules/image_order.rst
@@ -1,0 +1,75 @@
+Image Descriptor and Modules
+=========================
+
+.. contents::
+    :backlinks: none
+
+.. note::
+    This chapter applies to :doc:`builder engines </handbook/building/builder-engines>` that use Dockerfile as the input.
+
+
+While :doc:`module processing </handbook/modules/merging>` chapter covered the template processing modules this section
+describes how the image processing interacts with the module processing.
+
+
+.. graphviz::
+    :align: center
+    :alt: Module installation
+    :name: module-installation-diagram
+
+     digraph module_installation {
+        graph [fontsize="11", fontname="Open Sans", compound="true", splines=ortho, nodesep=0.5, ranksep=0.75];
+        node [shape="box", fontname="Open Sans", fontsize="10"];
+
+        // main rendering
+        subgraph cluster_0 {
+                label="Main Rendering Generation";
+                builder [label="Builder image handling"];
+                from [label="FROM generation"];
+                extra [label="Extra directory copying"];
+                image [label="Image Processing"];
+                cleanup [label="Cleanup"];
+                final [label="Final stages", href="#final-stages"];
+        }
+
+        // process_image
+        subgraph cluster_1 {
+                label="Image Rendering";
+                cachito [label="Cachito Support", rank=same];
+                repo [label="Repository Management"];
+                module [label="Included Module Processing"];
+                complete_image [label="Final Image stages", href="#final-image-stages"];
+        }
+
+        // process_module
+        subgraph cluster_2 {
+                artifact [label="Artifact copying", rank=same];
+                pkg_install [label="Package installation"];
+                ports [label="Expose Ports"];
+                run [label="Run scripts"];
+                volumes [label="Configure volumes"];
+        }
+
+        // graph control
+        builder -> from -> extra -> image -> cleanup -> final;
+        cachito -> repo -> module -> complete_image;
+        artifact -> pkg_install -> ports -> run -> volumes;
+
+        // subgraph links
+        builder -> cachito[constraint=false];
+        image -> cachito[constraint=false];
+        module -> artifact[constraint=false];
+        complete_image -> artifact[constraint=false];
+    }
+
+
+Final Stages
+"""""""""""""""""""""""
+
+This encompasses defining the ``USER``, the ``WORKDIR``, and ``ENTRYPOINT``. Finally the ``RUN`` command is generated.
+
+Final Image Stages
+"""""""""""""""""""""""
+
+This encompasses the final part of the generation for the image descriptor which may include e.g. package installation.
+Note that this happens **after** modules have been included and processed.

--- a/docs/handbook/modules/index.rst
+++ b/docs/handbook/modules/index.rst
@@ -9,3 +9,4 @@ to succeed with CEKit.
 
     merging
     versioning
+    image_order

--- a/docs/handbook/modules/merging.rst
+++ b/docs/handbook/modules/merging.rst
@@ -7,6 +7,7 @@ Module processing
 .. note::
     This chapter applies to :doc:`builder engines </handbook/building/builder-engines>` that use Dockerfile as the input.
 
+
 Understanding how modules are merged together is important. This knowledge will let you
 introduce modules that work better together and make rebuilds faster which is an important
 aspect of the image and module development.
@@ -93,6 +94,11 @@ would slow subsequent package manager executions. You should also not worry abou
 because every image is squashed (depends on builder though).
 
 Package installation is executed as ``root`` user.
+
+.. note::
+    It is only possible to define a single package manager for an image (although multi-stage images may have
+    different package managers). A package manager may be defined in a module or in an image (the latter takes
+    precedence).
 
 Environment variables
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ skip=__init__.py,.tox
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501
+extend-ignore = E203, E501, W503
 
 [tool:pytest]
 filterwarnings = ignore::DeprecationWarning:docker

--- a/tests/test_integ_builder_osbs.py
+++ b/tests/test_integ_builder_osbs.py
@@ -1932,19 +1932,6 @@ redhat = True
     COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
     WORKDIR $REMOTE_SOURCE_DIR/app
 
-###### START image 'operator-builder:7.11'
-###### \\
-        # Set 'operator-builder' image defined environment variables
-        ENV \\
-            JBOSS_IMAGE_NAME="rhpam-7/rhpam-kogito-operator" \\
-            JBOSS_IMAGE_VERSION="7.11"
-        # Set 'operator-builder' image defined labels
-        LABEL \\
-            name="rhpam-7/rhpam-kogito-operator" \\
-            version="7.11"
-###### /
-###### END image 'operator-builder:7.11'
-
 ###### START module 'org.kie.kogito.builder:7.11'
 ###### \\
         # Copy 'org.kie.kogito.builder' module general artifacts to '/workspace/' destination
@@ -1958,6 +1945,19 @@ redhat = True
         RUN [ "sh", "-x", "/tmp/scripts/org.kie.kogito.builder/install.sh" ]
 ###### /
 ###### END module 'org.kie.kogito.builder:7.11'
+
+###### START image 'operator-builder:7.11'
+###### \\
+        # Set 'operator-builder' image defined environment variables
+        ENV \\
+            JBOSS_IMAGE_NAME="rhpam-7/rhpam-kogito-operator" \\
+            JBOSS_IMAGE_VERSION="7.11"
+        # Set 'operator-builder' image defined labels
+        LABEL \\
+            name="rhpam-7/rhpam-kogito-operator" \\
+            version="7.11"
+###### /
+###### END image 'operator-builder:7.11'
 
     RUN rm -rf $REMOTE_SOURCE_DIR
 
@@ -2125,19 +2125,6 @@ redhat = True
     FROM registry.access.redhat.com/ubi8/go-toolset:1.14.12 AS operator-builder-one
     USER root
 
-###### START image 'operator-builder-one:7.11'
-###### \\
-        # Set 'operator-builder-one' image defined environment variables
-        ENV \\
-            JBOSS_IMAGE_NAME="rhpam-7/rhpam-kogito-operator" \\
-            JBOSS_IMAGE_VERSION="7.11"
-        # Set 'operator-builder-one' image defined labels
-        LABEL \\
-            name="rhpam-7/rhpam-kogito-operator" \\
-            version="7.11"
-###### /
-###### END image 'operator-builder-one:7.11'
-
 ###### START module 'org.kie.kogito.builder:7.11'
 ###### \\
         # Copy 'org.kie.kogito.builder' module general artifacts to '/workspace/' destination
@@ -2151,6 +2138,19 @@ redhat = True
         RUN [ "sh", "-x", "/tmp/scripts/org.kie.kogito.builder/install.sh" ]
 ###### /
 ###### END module 'org.kie.kogito.builder:7.11'
+
+###### START image 'operator-builder-one:7.11'
+###### \\
+        # Set 'operator-builder-one' image defined environment variables
+        ENV \\
+            JBOSS_IMAGE_NAME="rhpam-7/rhpam-kogito-operator" \\
+            JBOSS_IMAGE_VERSION="7.11"
+        # Set 'operator-builder-one' image defined labels
+        LABEL \\
+            name="rhpam-7/rhpam-kogito-operator" \\
+            version="7.11"
+###### /
+###### END image 'operator-builder-one:7.11'
 
 
 ## /


### PR DESCRIPTION
Fix handling of package managers in included repositories. Improve documentation.

Revert "Install modules (including executions) *after* packages are installed, not before."
This reverts commit e9410afcadd13a13a7d8a57e23ce6666ec038ecc.



Fixes #805 