### PR TITLE
Issue-813: Stripping package version in package listing command

### DIFF
--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -43,7 +43,7 @@ rm{% for repo in repositories %} /etc/yum.repos.d/{{ repo.filename }}{% endfor %
     {% if pkg_manager == 'microdnf' %}
             && {{ pkg_manager }} clean all \
     {% endif %}
-            && {{ helper.package_manager_query(pkg_manager) }}{% for package in packages %} {{ package }}{% endfor %}
+            && {{ helper.package_manager_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %}
     {% endif %}
 {%- endmacro -%}
 

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -541,15 +541,15 @@ def test_supported_package_managers_apt(tmpdir, caplog):
         descriptor={
             "packages": {
                 "manager": "apt-get",
-                "install": ["a"],
+                "install": ["a", "b=1.0.0"],
                 "repositories": [{"name": "foo", "rpm": "foo-repo.rpm"}],
             }
         },
     )
     regex_dockerfile(
-        target, "RUN apt-get update && apt-get --no-install-recommends install -y a"
+        target, "RUN apt-get update && apt-get --no-install-recommends install -y a b=1.0.0"
     )
-    regex_dockerfile(target, "dpkg-query --list a")
+    regex_dockerfile(target, "dpkg-query --list a b")
     assert (
         "Package manager apt-get does not support defining repositories, skipping all repositories"
         in caplog.text

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -547,7 +547,8 @@ def test_supported_package_managers_apt(tmpdir, caplog):
         },
     )
     regex_dockerfile(
-        target, "RUN apt-get update && apt-get --no-install-recommends install -y a b=1.0.0"
+        target,
+        "RUN apt-get update && apt-get --no-install-recommends install -y a b=1.0.0",
     )
     regex_dockerfile(target, "dpkg-query --list a b")
     assert (


### PR DESCRIPTION
Fixes #813

If the installable package contains the version, then the package listing command (`dpkg-query --list`) throws an error because it appends the version with the package name in the search query.
The error looks like this,
`dpkg-query --list xyz=1.x.y' returned a non-zero code: 1`

This PR fixes that issue simply by stripping the version part and using only the package name as the input for `dpkg-query --list` command.