### PR TITLE
Add type hints.

### DIFF
--- a/cekit/builders/buildah.py
+++ b/cekit/builders/buildah.py
@@ -3,6 +3,7 @@ import os
 
 from cekit.builder import Builder
 from cekit.tools import run_wrapper
+from cekit.types import DependencyDefinition
 
 LOGGER = logging.getLogger("cekit")
 
@@ -14,14 +15,14 @@ class BuildahBuilder(Builder):
         super(BuildahBuilder, self).__init__("buildah", params)
 
     @staticmethod
-    def dependencies(params=None):
+    def dependencies(params=None) -> DependencyDefinition:
         deps = {}
 
         deps["buildah"] = {"package": "buildah", "executable": "buildah"}
 
         return deps
 
-    def run(self):
+    def run(self) -> None:
         """Build container image using buildah."""
         tags = self.params.tags
         cmd = ["/usr/bin/buildah", "build-using-dockerfile"]

--- a/cekit/builders/docker_builder.py
+++ b/cekit/builders/docker_builder.py
@@ -5,6 +5,7 @@ import traceback
 
 from cekit.builder import Builder
 from cekit.errors import CekitError
+from cekit.types import DependencyDefinition
 
 LOGGER = logging.getLogger("cekit")
 
@@ -48,7 +49,7 @@ class DockerBuilder(Builder):
         super(DockerBuilder, self).__init__("docker", params)
 
     @staticmethod
-    def dependencies(params=None):
+    def dependencies(params=None) -> DependencyDefinition:
         deps = {}
 
         deps["python-docker"] = {
@@ -111,6 +112,7 @@ class DockerBuilder(Builder):
 
         except requests.ConnectionError as ex:
             exception_chain = traceback.format_exc()
+            # TODO: exc_info should probably be True rather than 1.
             LOGGER.debug(
                 "Caught ConnectionError attempting to communicate with Docker ",
                 exc_info=1,

--- a/cekit/builders/osbs.py
+++ b/cekit/builders/osbs.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import List
+from typing import TYPE_CHECKING, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from jinja2 import Template
@@ -15,6 +15,7 @@ from cekit import tools
 from cekit.builder import Builder
 from cekit.config import Config
 from cekit.descriptor.resource import (
+    Resource,
     _ImageContentResource,
     _PlainResource,
     _PncResource,
@@ -22,6 +23,10 @@ from cekit.descriptor.resource import (
 )
 from cekit.errors import CekitError
 from cekit.tools import Chdir, copy_recursively, run_wrapper
+from cekit.types import DependencyDefinition, PathType
+
+if TYPE_CHECKING:
+    from cekit.descriptor.osbs import Repository
 
 LOGGER = logging.getLogger("cekit")
 CONFIG = Config()
@@ -34,7 +39,8 @@ class OSBSBuilder(Builder):
         super(OSBSBuilder, self).__init__("osbs", params)
 
         self._rhpkg_set_url_repos: List[str] = []
-        self.artifacts: List[str] = []
+        # TODO: artifacts is used as two different, incompatible types here
+        self.artifacts: List[Resource] = []
         self.dist_git: DistGit
         self.dist_git_dir: pathlib.Path
 
@@ -53,7 +59,7 @@ class OSBSBuilder(Builder):
             self._koji_url = "https://koji.fedoraproject.org/koji"
 
     @staticmethod
-    def dependencies(params=None):
+    def dependencies(params=None) -> DependencyDefinition:
         deps = {}
 
         if CONFIG.get("common", "redhat"):
@@ -76,7 +82,7 @@ class OSBSBuilder(Builder):
 
         return deps
 
-    def before_build(self):
+    def before_build(self) -> None:
         """Prepares dist-git repository for OSBS build."""
 
         super(OSBSBuilder, self).before_build()
@@ -86,9 +92,12 @@ class OSBSBuilder(Builder):
         self._sync_with_dist_git()
 
     def _prepare_dist_git(self):
-        repository_key = self.generator.image.get("osbs", {}).get("repository", {})
-        repository = repository_key.get("name")
-        branch = repository_key.get("branch")
+        # TODO: Replace with actual type-safe getters.
+        repository_key: "Repository" = self.generator.image.get("osbs", {}).get(
+            "repository", {}
+        )
+        repository: str = repository_key.get("name")
+        branch: str = repository_key.get("branch")
 
         if not (repository and branch):
             raise CekitError(
@@ -102,13 +111,13 @@ class OSBSBuilder(Builder):
 
         # We need to prepare a list of all artifacts in every image (in case
         # of multi-stage builds) and in every module.
-        all_artifacts = []
+        all_artifacts: List[Resource] = []
 
         for image in self.generator.images:
             all_artifacts += image.all_artifacts
 
         # First get all artifacts that are not plain/url artifacts (the latter is added to fetch-artifacts.yaml)
-        self.artifacts = [
+        self.artifacts: List[Resource] = [
             a.target
             for a in all_artifacts
             if not isinstance(
@@ -138,7 +147,7 @@ class OSBSBuilder(Builder):
                 for x in self.generator.image["packages"]["set_url"]
             ]
 
-        self.dist_git_dir = os.path.join(
+        self.dist_git_dir: PathType = os.path.join(
             os.path.expanduser(CONFIG.get("common", "work_dir")), osbs_dir, repository
         )
         if not os.path.exists(os.path.dirname(self.dist_git_dir)):
@@ -151,11 +160,13 @@ class OSBSBuilder(Builder):
             self.target,
             repository,
             branch,
+            # TODO: default result, dict, doesn't have attribute `extra_dir`
             self.generator.image.get("osbs", {}).extra_dir,
             self.params.assume_yes,
         )
 
         self.dist_git.prepare(self.params.stage, self.params.user)
+        # TODO: There is a type error here that need resolving.
         self.dist_git.clean(self.artifacts)
 
     def _copy_to_dist_git(self):
@@ -343,7 +354,7 @@ class DistGit(object):
     """Git support for osbs repositories"""
 
     @staticmethod
-    def repo_info(path):
+    def repo_info(path) -> Tuple[str, str, str]:
         with Chdir(path):
             if (
                 run_wrapper(["git", "rev-parse", "--is-inside-work-tree"], True).stdout
@@ -354,24 +365,32 @@ class DistGit(object):
                     "Please make sure you specified correct path.".format(path)
                 )
 
-            name = os.path.basename(
+            name: str = os.path.basename(
                 run_wrapper(["git", "rev-parse", "--show-toplevel"], True).stdout
             )
-            branch = run_wrapper(
+            branch: str = run_wrapper(
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"], True
             ).stdout
-            commit = run_wrapper(["git", "rev-parse", "HEAD"], True).stdout
+            commit: str = run_wrapper(["git", "rev-parse", "HEAD"], True).stdout
 
         return name, branch, commit
 
-    def __init__(self, output, source, repo, branch, osbs_extra, noninteractive=False):
-        self.output = output
-        self.source = source
-        self.repo = repo
-        self.branch = branch
-        self.osbs_extra = osbs_extra
-        self.dockerfile = os.path.join(self.output, "Dockerfile")
-        self.noninteractive = noninteractive
+    def __init__(
+        self,
+        output: PathType,
+        source: PathType,
+        repo: str,
+        branch: str,
+        osbs_extra: PathType,
+        noninteractive: bool = False,
+    ):
+        self.output: PathType = output
+        self.source: PathType = source
+        self.repo: str = repo
+        self.branch: str = branch
+        self.osbs_extra: PathType = osbs_extra
+        self.dockerfile: PathType = os.path.join(self.output, "Dockerfile")
+        self.noninteractive: bool = noninteractive
 
         (
             self.source_repo_name,
@@ -389,7 +408,7 @@ class DistGit(object):
 
         return False
 
-    def prepare(self, stage, user=None) -> None:
+    def prepare(self, stage, user: Optional[str] = None) -> None:
         if os.path.exists(self.output):
             with Chdir(self.output):
                 LOGGER.info("Fetching latest changes in repo {}...".format(self.repo))
@@ -460,6 +479,7 @@ class DistGit(object):
     def add(self, artifacts: List[str]) -> None:
         LOGGER.debug("Adding files to git...")
 
+        # TODO: Rename obj to something specific
         for obj in os.listdir("."):
             if obj == ".git":
                 LOGGER.debug("Skipping '.git' directory")

--- a/cekit/builders/podman.py
+++ b/cekit/builders/podman.py
@@ -1,8 +1,10 @@
 import logging
 import os
+from typing import List
 
 from cekit.builder import Builder
 from cekit.tools import run_wrapper
+from cekit.types import DependencyDefinition
 
 LOGGER = logging.getLogger("cekit")
 
@@ -14,7 +16,7 @@ class PodmanBuilder(Builder):
         super(PodmanBuilder, self).__init__("podman", params)
 
     @staticmethod
-    def dependencies(params=None):
+    def dependencies(params=None) -> DependencyDefinition:
         deps = {}
 
         deps["podman"] = {"package": "podman", "executable": "podman"}
@@ -23,8 +25,8 @@ class PodmanBuilder(Builder):
 
     def run(self):
         """Build container image using podman."""
-        tags = self.params.tags
-        cmd = ["/usr/bin/podman", "build"]
+        tags: List[str] = self.params.tags
+        cmd: List[str] = ["/usr/bin/podman", "build"]
 
         if not tags:
             tags = self.generator.get_tags()

--- a/cekit/cache/artifact.py
+++ b/cekit/cache/artifact.py
@@ -1,12 +1,17 @@
 import glob
 import os
 import uuid
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 import yaml
 
 from cekit.config import Config
 from cekit.crypto import SUPPORTED_HASH_ALGORITHMS, get_sum
 from cekit.errors import CekitError
+from cekit.types import PathType
+
+if TYPE_CHECKING:
+    from cekit.descriptor import Resource
 
 CONFIG = Config()
 
@@ -19,13 +24,13 @@ class ArtifactCache:
     """
 
     def __init__(self):
-        self.cache_dir = os.path.expanduser(
+        self.cache_dir: PathType = os.path.expanduser(
             os.path.join(CONFIG.get("common", "work_dir"), "cache")
         )
         if not os.path.exists(self.cache_dir):
             os.makedirs(self.cache_dir)
 
-    def _get_cache(self):
+    def _get_cache(self) -> Dict[str, Any]:
         cache = {}
         for index_file in glob.glob(os.path.join(self.cache_dir, "*.yaml")):
             with open(index_file, "r") as file_:
@@ -33,29 +38,31 @@ class ArtifactCache:
 
         return cache
 
-    def _update_cache(self, cache_entry, artifact_id):
+    def _update_cache(self, cache_entry: Any, artifact_id: str) -> None:
         index_file = os.path.join(self.cache_dir, artifact_id + ".yaml")
         tmp_cache_file = index_file + str(os.getpid())
         with open(tmp_cache_file, "w") as file_:
             yaml.safe_dump(cache_entry, file_)
             os.rename(tmp_cache_file, index_file)
 
-    def list(self):
+    def list(self) -> Dict[str, Any]:
         return self._get_cache()
 
-    def add(self, artifact):
+    def add(self, artifact: "Resource"):
+        # TODO: This line works, but it really is non-obvious why.
         if not set(SUPPORTED_HASH_ALGORITHMS).intersection(artifact):
             raise ValueError("Cannot cache artifact without checksum")
 
         if self.cached(artifact):
             raise CekitError("Artifact is already cached!")
 
-        artifact_id = str(uuid.uuid4())
+        artifact_id: str = str(uuid.uuid4())
 
         artifact_file = os.path.expanduser(os.path.join(self.cache_dir, artifact_id))
         if not os.path.exists(artifact_file):
             artifact.guarded_copy(artifact_file)
 
+        # TODO: replace this with a specific type/class
         cache_entry = {"names": [artifact["name"]], "cached_path": artifact_file}
 
         # We should populate the cache entry with checksums for all supported algorithms
@@ -67,17 +74,18 @@ class ArtifactCache:
 
     def delete(self, artifact_uuid):
         # check if artifact exists
+        # TODO: This doesn't actually appear to check anything
         self._get_cache()
         os.remove(os.path.join(self.cache_dir, artifact_uuid))
         os.remove(os.path.join(self.cache_dir, artifact_uuid + ".yaml"))
 
-    def get(self, artifact):
+    def get(self, artifact: "Resource"):
         for alg in SUPPORTED_HASH_ALGORITHMS:
             if alg in artifact:
                 return self._find_artifact(alg, artifact[alg])
         raise CekitError("Artifact is not cached.")
 
-    def _find_artifact(self, alg, chksum):
+    def _find_artifact(self, alg: str, chksum: str):
         cache = self._get_cache()
         for _, artifact in cache.items():
             if alg in artifact and artifact[alg] == chksum:
@@ -85,7 +93,8 @@ class ArtifactCache:
 
         raise CekitError("Artifact is not cached.")
 
-    def cached(self, artifact):
+    # TODO: Make this return Optional[Resource] instead of Union[Resource, bool]
+    def cached(self, artifact: "Resource") -> Union["Resource", bool]:
         try:
             return self.get(artifact)
         except CekitError:

--- a/cekit/cache/cli.py
+++ b/cekit/cache/cli.py
@@ -151,7 +151,7 @@ class CacheCli:
         else:
             click.echo("No artifacts cached!")
 
-    def rm(self, uuid):
+    def rm(self, uuid: str):
         artifact_cache = ArtifactCache()
 
         try:

--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 from subprocess import CalledProcessError
+from typing import TYPE_CHECKING, Optional, Type
 
 import click
 
@@ -13,6 +14,9 @@ from cekit.errors import CekitError
 from cekit.log import setup_logging
 from cekit.tools import Map
 from cekit.version import __version__
+
+if TYPE_CHECKING:
+    from cekit.builder import Command
 
 LOGGER = logging.getLogger("cekit")
 CONFIG = Config()
@@ -348,7 +352,7 @@ def test_behave(ctx, steps_url, wip, names):
     run_test(ctx, "behave")
 
 
-def prepare_params(ctx, params=None):
+def prepare_params(ctx, params: Optional[Map] = None) -> Map:
 
     if params is None:
         params = Map({})
@@ -361,8 +365,8 @@ def prepare_params(ctx, params=None):
     return params
 
 
-def run_command(ctx, clazz):
-    params = prepare_params(ctx)
+def run_command(ctx, clazz: Type["Command"]):
+    params: Map = prepare_params(ctx)
     Cekit(params).run(clazz)
 
 
@@ -405,8 +409,8 @@ def run_build(ctx, builder):
 class Cekit(object):
     """Main application"""
 
-    def __init__(self, params):
-        self.params = params
+    def __init__(self, params: Map):
+        self.params: Map = params
 
     def init(self):
         """Initialize logging"""
@@ -455,7 +459,7 @@ class Cekit(object):
                 except Exception:
                     raise CekitError("Unable to clean directory '{}'".format(directory))
 
-    def run(self, clazz):
+    def run(self, clazz: Type["Command"]):
         """Main application entry"""
 
         self.init()

--- a/cekit/config.py
+++ b/cekit/config.py
@@ -1,7 +1,10 @@
 import configparser
 import os
+from typing import Any, Dict, Optional
 
 import yaml
+
+from cekit.types import PathType
 
 default_work_dir = "~/.cekit"
 
@@ -12,12 +15,12 @@ class Config(object):
     cfg = {}
 
     @classmethod
-    def configure(cls, config_path, cmdline_args):
+    def configure(cls, config_path: PathType, cmdline_args: Dict[str, Any]) -> None:
         cls._load_cfg(config_path)
         cls._override_config(cmdline_args)
 
     @classmethod
-    def _override_config(cls, cmdline_args):
+    def _override_config(cls, cmdline_args: Dict[str, Any]) -> None:
         # Only allow command line overriding of these values if they are not the default value.
         if cmdline_args.get("redhat"):
             cls.cfg["common"]["redhat"] = cmdline_args.get("redhat")
@@ -28,7 +31,7 @@ class Config(object):
             cls.cfg["common"]["work_dir"] = cmdline_args.get("work_dir")
 
     @classmethod
-    def _load_cfg(cls, config_path):
+    def _load_cfg(cls, config_path: PathType) -> None:
         """Loads configuration from cekit config file
 
         params:
@@ -36,6 +39,7 @@ class Config(object):
         """
         config_parser = configparser.ConfigParser()
         config_parser.read(os.path.expanduser(config_path))
+        # TODO: Fix this reference to protected member of class we don't control!
         cls.cfg = config_parser._sections
         cls.cfg["common"] = cls.cfg.get("common", {})
         cls.cfg["common"]["work_dir"] = cls.cfg.get("common").get(
@@ -49,7 +53,7 @@ class Config(object):
         )
 
     @classmethod
-    def get(cls, *args):
+    def get(cls, *args) -> Optional[str]:
         """Returns key value located by path of *args,
         None if Key doesn't exists,
 

--- a/cekit/crypto.py
+++ b/cekit/crypto.py
@@ -2,6 +2,8 @@ import hashlib
 import logging
 from typing import List
 
+from cekit.types import PathType
+
 logger = logging.getLogger("cekit")
 
 SUPPORTED_HASH_ALGORITHMS: List[str] = ["sha512", "sha256", "sha1", "md5"]
@@ -12,7 +14,7 @@ SUPPORTED_SOURCE_HASH_ALGORITHMS: List[str] = [
 ]
 
 
-def get_sum(target, algorithm):
+def get_sum(target: PathType, algorithm: str) -> str:
     hash_function = getattr(hashlib, algorithm)()
 
     logger.debug("Computing {} checksum for '{}' file".format(algorithm, target))
@@ -23,7 +25,7 @@ def get_sum(target, algorithm):
     return hash_function.hexdigest()
 
 
-def check_sum(target, algorithm, expected):
+def check_sum(target: PathType, algorithm: str, expected: str) -> bool:
     """Check that file checksum is correct
     Args:
       alg - algorithm which will be used for digest

--- a/cekit/descriptor/env.py
+++ b/cekit/descriptor/env.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import yaml
 
 from cekit.descriptor import Descriptor
@@ -24,33 +26,35 @@ class Env(Descriptor):
         super(Env, self).__init__(descriptor)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.get("name")
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._descriptor["name"] = value
 
     @property
-    def value(self):
+    def value(self) -> Any:
+        # TODO: These should be string, need to update the schema.
         return self.get("value")
 
     @value.setter
-    def value(self, value):
+    def value(self, value: Any):
         self._descriptor["value"] = value
 
     @property
-    def example(self):
+    def example(self) -> Any:
+        # TODO: These should be string, need to update the schema.
         return self.get("example")
 
     @example.setter
-    def example(self, value):
+    def example(self, value: Any):
         self._descriptor["example"] = value
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self.get("description")
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str):
         self._descriptor["description"] = value

--- a/cekit/descriptor/execute.py
+++ b/cekit/descriptor/execute.py
@@ -13,6 +13,7 @@ execute_schemas = yaml.safe_load(
           user: {type: text}"""
 )
 
+# TODO: This seems unused?
 container_schemas = yaml.safe_load(
     """
         seq:
@@ -34,25 +35,25 @@ class Execute(Descriptor):
             descriptor["name"] = "{}/{}".format(module_name, descriptor["script"])
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.get("name")
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._descriptor["name"] = value
 
     @property
-    def script(self):
+    def script(self) -> str:
         return self.get("script")
 
     @script.setter
-    def script(self, value):
+    def script(self, value: str):
         self._descriptor["script"] = value
 
     @property
-    def user(self):
+    def user(self) -> str:
         return self.get("user", cekit.DEFAULT_USER)
 
     @user.setter
-    def user(self, value):
+    def user(self, value: str):
         self._descriptor["user"] = value

--- a/cekit/descriptor/label.py
+++ b/cekit/descriptor/label.py
@@ -19,30 +19,30 @@ class Label(Descriptor):
       descriptor - yaml object with Label
     """
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor: dict):
         self.schema = label_schemas
         super(Label, self).__init__(descriptor)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.get("name")
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._descriptor["name"] = value
 
     @property
-    def value(self):
+    def value(self) -> str:
         return self.get("value")
 
     @value.setter
-    def value(self, value):
+    def value(self, value: str):
         self._descriptor["value"] = value
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self.get("description")
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str):
         self._descriptor["description"] = value

--- a/cekit/descriptor/module.py
+++ b/cekit/descriptor/module.py
@@ -1,5 +1,8 @@
+from typing import List
+
 from cekit.descriptor import Execute, Image
 from cekit.descriptor.image import get_image_schema
+from cekit.types import RawDescriptor
 
 overrides_schema = get_image_schema()
 overrides_schema["map"]["execute"] = {"type": "any"}
@@ -12,7 +15,7 @@ class Module(Image):
     descriptor_path: A path to module descriptor file.
     """
 
-    def __init__(self, descriptor, path, artifact_dir):
+    def __init__(self, descriptor: RawDescriptor, path, artifact_dir):
         self._artifact_dir = artifact_dir
         self.path = path
         self.schema = overrides_schema.copy()
@@ -27,5 +30,5 @@ class Module(Image):
         ]
 
     @property
-    def execute(self):
+    def execute(self) -> List[Execute]:
         return self.get("execute")

--- a/cekit/descriptor/modules.py
+++ b/cekit/descriptor/modules.py
@@ -1,7 +1,9 @@
+from typing import Any, List
+
 import yaml
 
 from cekit.descriptor import Descriptor
-from cekit.descriptor.resource import create_resource
+from cekit.descriptor.resource import Resource, create_resource
 
 modules_schema = yaml.safe_load(
     """
@@ -35,11 +37,11 @@ class Modules(Descriptor):
         ]
 
     @property
-    def repositories(self):
+    def repositories(self) -> List[Resource]:
         return self.get("repositories")
 
     @property
-    def install(self):
+    def install(self) -> List["Install"]:
         return self.get("install")
 
 
@@ -49,17 +51,18 @@ class Install(Descriptor):
         super(Install, self).__init__(descriptor)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.get("name")
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._descriptor["name"] = value
 
     @property
-    def version(self):
+    def version(self) -> Any:
+        # TODO: convert to string up front to simplify things.
         return self.get("version")
 
     @version.setter
-    def version(self, value):
+    def version(self, value: Any):
         self._descriptor["version"] = value

--- a/cekit/descriptor/osbs.py
+++ b/cekit/descriptor/osbs.py
@@ -1,10 +1,12 @@
 import logging
 import os
+from typing import Any, Callable
 
 import yaml
 
 from cekit.descriptor import Descriptor
 from cekit.errors import CekitError
+from cekit.types import PathType
 
 osbs_schema = yaml.safe_load(
     """
@@ -60,7 +62,8 @@ class Osbs(Descriptor):
             self._descriptor.get("repository", {}), self.descriptor_path
         )
 
-    def merge(self, descriptor):
+    # TODO: Unclear why merge is overridden here with a different implementation.
+    def merge(self, descriptor: "Osbs") -> "Osbs":
         if not descriptor:
             return self
         for k2, v2 in descriptor.items():
@@ -69,51 +72,51 @@ class Osbs(Descriptor):
         return self
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.get("name")
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._descriptor["name"] = value
 
     @property
-    def branch(self):
+    def branch(self) -> str:
         return self.get("branch")
 
     @branch.setter
-    def branch(self, value):
+    def branch(self, value: str):
         self._descriptor["branch"] = value
 
     @property
-    def configuration(self):
+    def configuration(self) -> "Configuration":
         return self.get("configuration")
 
     @property
-    def extra_dir(self):
+    def extra_dir(self) -> PathType:
         return self.get("extra_dir")
 
     @extra_dir.setter
-    def extra_dir(self, value):
+    def extra_dir(self, value: PathType):
         self._descriptor["extra_dir"] = value
 
     @property
-    def extra_dir_target(self):
+    def extra_dir_target(self) -> PathType:
         return self.get("extra_dir_target")
 
     @extra_dir_target.setter
-    def extra_dir_target(self, value):
+    def extra_dir_target(self, value: PathType):
         self._descriptor["extra_dir_target"] = value
 
     @property
-    def koji_target(self):
+    def koji_target(self) -> str:
         return self.get("koji_target")
 
     @koji_target.setter
-    def koji_target(self, value):
+    def koji_target(self, value: str):
         self._descriptor["koji_target"] = value
 
     @property
-    def repository(self):
+    def repository(self) -> "Repository":
         return self.get("repository")
 
 
@@ -123,9 +126,9 @@ class Configuration(Descriptor):
     Args:
       descriptor - yaml containing OSBS configuration"""
 
-    def __init__(self, descriptor, descriptor_path):
+    def __init__(self, descriptor: Any, descriptor_path: str):
         self.schema = configuration_schema
-        self.descriptor_path = descriptor_path
+        self.descriptor_path: str = descriptor_path
         super(Configuration, self).__init__(descriptor)
 
         self._process_osbs_config_files(yaml.safe_load, "container", "container_file")
@@ -137,7 +140,9 @@ class Configuration(Descriptor):
         if remote_source:
             logger.debug("Cachito definition is {}".format(remote_source))
 
-    def _process_osbs_config_files(self, loader, text, filename):
+    def _process_osbs_config_files(
+        self, loader: Callable[[Any], Any], text: str, filename: str
+    ) -> None:
         if text in self and filename in self:
             raise CekitError(
                 "You cannot specify %s and %s together!" % (text, filename)

--- a/cekit/descriptor/overrides.py
+++ b/cekit/descriptor/overrides.py
@@ -1,7 +1,9 @@
 import copy
+from typing import Optional
 
 from cekit.descriptor import Image
 from cekit.descriptor.image import get_image_schema
+from cekit.types import RawDescriptor
 
 overrides_schema = get_image_schema()
 overrides_schema["map"]["name"] = {"type": "str"}
@@ -9,13 +11,13 @@ overrides_schema["map"]["version"] = {"type": "text"}
 
 
 class Overrides(Image):
-    def __init__(self, descriptor, artifact_dir):
-        self.original_descriptor = copy.deepcopy(descriptor)
-        self._artifact_dir = artifact_dir
+    def __init__(self, descriptor: RawDescriptor, artifact_dir: Optional[str]):
+        self.original_descriptor: RawDescriptor = copy.deepcopy(descriptor)
+        self._artifact_dir: str = artifact_dir
         self.path = artifact_dir
         schema = overrides_schema.copy()
         self.schema = schema
         # calling Descriptor constructor only here (we don't want Image() to mess with schema)
         super(Image, self).__init__(descriptor)
-
+        # TODO: This doesn't set `skip_merging` (though overrides probably aren't merged anywhere)
         self._prepare()

--- a/cekit/descriptor/packages.py
+++ b/cekit/descriptor/packages.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import List
 
 import yaml
 
@@ -7,6 +8,7 @@ from cekit.config import Config
 from cekit.descriptor import Descriptor
 from cekit.descriptor.resource import create_resource
 from cekit.errors import CekitError
+from cekit.types import ContentSetType
 
 logger = logging.getLogger("cekit")
 config = Config()
@@ -99,6 +101,7 @@ class Packages(Descriptor):
         else:
             self._descriptor["repositories"] = [Repository(x) for x in repositories]
 
+        # TODO: This looks like a no-op?!
         self._descriptor["install"] = self._descriptor.get("install", [])
 
     @property
@@ -110,15 +113,16 @@ class Packages(Descriptor):
         return self.get("manager_flags")
 
     @property
-    def repositories(self):
+    def repositories(self) -> List["Repository"]:
         return self.get("repositories")
 
     @property
-    def install(self):
+    def install(self) -> List[str]:
         return self.get("install")
 
     @property
-    def content_sets(self):
+    def content_sets(self) -> ContentSetType:
+        # TODO: content_sets seems to be undocumented?! Not sure what this is.
         return self.get("content_sets")
 
     @content_sets.setter

--- a/cekit/descriptor/port.py
+++ b/cekit/descriptor/port.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import yaml
 
 from cekit.descriptor.base import Descriptor
@@ -20,48 +22,49 @@ class Port(Descriptor):
     args:
        descriptor - yaml object containing Port definition"""
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor: Any):
         self.schema = port_schemas
         super(Port, self).__init__(descriptor)
         if "name" not in self._descriptor:
+            # TODO: Name probably has to be a string...
             self._descriptor["name"] = self._descriptor["value"]
 
     @property
-    def value(self):
+    def value(self) -> int:
         return self.get("value")
 
     @value.setter
-    def value(self, value):
+    def value(self, value: int):
         self._descriptor["value"] = value
 
     @property
-    def protocol(self):
+    def protocol(self) -> str:
         return self.get("protocol")
 
     @protocol.setter
-    def protocol(self, value):
+    def protocol(self, value: str):
         self._descriptor["protocol"] = value
 
     @property
-    def service(self):
+    def service(self) -> str:
         return self.get("service")
 
     @service.setter
-    def service(self, value):
+    def service(self, value: str):
         self._descriptor["service"] = value
 
     @property
-    def expose(self):
+    def expose(self) -> bool:
         return self.get("expose")
 
     @expose.setter
-    def expose(self, value):
+    def expose(self, value: bool):
         self._descriptor["expose"] = value
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self.get("description")
 
     @description.setter
-    def description(self, value):
+    def description(self, value: str):
         self._descriptor["description"] = value

--- a/cekit/descriptor/resource.py
+++ b/cekit/descriptor/resource.py
@@ -2,20 +2,24 @@ import json
 import logging
 import os
 import shutil
+from typing import Any, Dict, Optional, overload
 
 from cekit.config import Config
 from cekit.crypto import SUPPORTED_HASH_ALGORITHMS, check_sum
 from cekit.descriptor import Descriptor
 from cekit.errors import CekitError
 from cekit.tools import Chdir, Map, download_file, get_brew_url, run_wrapper
+from cekit.types import _T, PathType
 
 logger = logging.getLogger("cekit")
 config = Config()
 
+RawResourceDescriptor = Dict[str, Any]
+
 artifact_dest = "/tmp/artifacts/"
 
 
-def create_resource(descriptor, **kwargs):
+def create_resource(descriptor: RawResourceDescriptor, **kwargs) -> "Resource":
     """
     Module method responsible for instantiating proper resource object
     based on the provided descriptor.
@@ -70,7 +74,7 @@ class Resource(Descriptor):
 
     CHECK_INTEGRITY = True
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor: RawResourceDescriptor):
         # Schema must be provided by the implementing class
         if not self.schema:
             raise CekitError(
@@ -94,7 +98,20 @@ class Resource(Descriptor):
         # forwarded import to prevent circular imports
         from cekit.cache.artifact import ArtifactCache
 
-        self.cache = ArtifactCache()
+        # TODO: This does not appear to be a circular import.
+
+        self.cache: ArtifactCache = ArtifactCache()
+
+    # TODO: Make `name` a property (probably on a parent class)
+
+    # TODO: This seems to unnecessarily use name mangling
+    @overload
+    def __to_map(self, dictionary: dict) -> Map:
+        pass
+
+    @overload
+    def __to_map(self, dictionary: _T) -> _T:
+        pass
 
     def __to_map(self, dictionary):
         """
@@ -131,7 +148,7 @@ class Resource(Descriptor):
             return not self["name"] == other["name"]
         return NotImplemented
 
-    def _ensure_name(self, descriptor):
+    def _ensure_name(self, descriptor: RawResourceDescriptor):
         """
         Makes sure the 'name' attribute exists.
 
@@ -164,13 +181,13 @@ class Resource(Descriptor):
 
         descriptor["name"] = default
 
-    def _ensure_target(self, descriptor):
+    def _ensure_target(self, descriptor: RawResourceDescriptor) -> None:
         if descriptor.get("target") is not None:
             return
 
         descriptor["target"] = self._get_default_target_value(descriptor)
 
-    def _normalize_dest(self, descriptor):
+    def _normalize_dest(self, descriptor: RawResourceDescriptor) -> None:
         """
         Make sure that the 'dest' value, if provided, does end with a single slash.
         """
@@ -178,7 +195,7 @@ class Resource(Descriptor):
         if descriptor.get("dest") is not None:
             descriptor["dest"] = os.path.normpath(descriptor.get("dest")) + "/"
 
-    def _get_default_name_value(self, descriptor):
+    def _get_default_name_value(self, descriptor: RawResourceDescriptor) -> str:
         """
         Returns default identifier value for particular class.
 
@@ -186,12 +203,14 @@ class Resource(Descriptor):
         Returned should be a string that will be be a unique identifier
         of the resource across thw whole image.
         """
+        # TODO: This is an abstract method, and hence should return NotImplementedError()
         return None
 
-    def _get_default_target_value(self, descriptor):
+    def _get_default_target_value(self, descriptor: RawResourceDescriptor) -> str:
         return os.path.basename(descriptor.get("name"))
 
-    def _copy_impl(self, target):
+    def _copy_impl(self, target: PathType) -> PathType:
+        # TODO: Return value is never used.
         raise NotImplementedError(
             "Implement _copy_impl() for Resource: "
             + self.__module__
@@ -199,7 +218,7 @@ class Resource(Descriptor):
             + type(self).__name__
         )
 
-    def copy(self, target=os.getcwd()):
+    def copy(self, target: PathType = os.getcwd()) -> PathType:
 
         if os.path.isdir(target):
             target = os.path.join(target, self.target)
@@ -225,7 +244,7 @@ class Resource(Descriptor):
             except ValueError:
                 return self.guarded_copy(target)
 
-    def guarded_copy(self, target):
+    def guarded_copy(self, target: PathType) -> PathType:
         try:
             self._copy_impl(target)
         except Exception as ex:
@@ -251,7 +270,7 @@ class Resource(Descriptor):
 
         return target
 
-    def __verify(self, target):
+    def __verify(self, target: PathType) -> bool:
         """Checks all defined check_sums for an artifact"""
         if not set(SUPPORTED_HASH_ALGORITHMS).intersection(self):
             logger.debug(
@@ -270,7 +289,8 @@ class Resource(Descriptor):
                     return False
         return True
 
-    def __substitute_cache_url(self, url):
+    # TODO: This seems to unnecessarily use name mangling.
+    def __substitute_cache_url(self, url: str) -> str:
         cache = config.get("common", "cache_url")
 
         if not cache:
@@ -292,7 +312,9 @@ class Resource(Descriptor):
 
         return url
 
-    def _download_file(self, url, destination, use_cache=True):
+    def _download_file(
+        self, url: Optional[str], destination: PathType, use_cache=True
+    ) -> None:
         """Downloads a file from url and save it as destination"""
         if use_cache:
             url = self.__substitute_cache_url(url)
@@ -330,7 +352,7 @@ class _PathResource(Resource):
         }
     }
 
-    def __init__(self, descriptor, directory):
+    def __init__(self, descriptor: RawResourceDescriptor, directory: PathType):
         self.schema = _PathResource.SCHEMA
 
         super(_PathResource, self).__init__(descriptor)
@@ -341,13 +363,13 @@ class _PathResource(Resource):
         if not os.path.isabs(path):
             self["path"] = os.path.join(directory, path)
 
-    def _get_default_name_value(self, descriptor):
+    def _get_default_name_value(self, descriptor: RawResourceDescriptor) -> str:
         """
         Default identifier is the last part (most probably file name) of the URL.
         """
         return os.path.basename(descriptor.get("path"))
 
-    def _copy_impl(self, target):
+    def _copy_impl(self, target: PathType) -> PathType:
         if not os.path.exists(self.path):
             cache = config.get("common", "cache_url")
 
@@ -418,7 +440,7 @@ class _UrlResource(Resource):
         }
     }
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor: RawResourceDescriptor):
         self.schema = _UrlResource.SCHEMA
 
         super(_UrlResource, self).__init__(descriptor)
@@ -427,16 +449,16 @@ class _UrlResource(Resource):
         self["url"] = descriptor.get("url").strip()
 
     # Avoid protected access warning
-    def download_file(self, url, destination):
-        return self._download_file(url, destination, False)
+    def download_file(self, url: str, destination: PathType):
+        return self._download_file(url, destination, use_cache=False)
 
-    def _get_default_name_value(self, descriptor):
+    def _get_default_name_value(self, descriptor: RawResourceDescriptor) -> str:
         """
         Default identifier is the last part (most probably file name) of the URL.
         """
         return os.path.basename(descriptor.get("url"))
 
-    def _copy_impl(self, target):
+    def _copy_impl(self, target: PathType) -> PathType:
         try:
             self._download_file(self.url, target)
         except Exception:
@@ -450,6 +472,7 @@ class _UrlResource(Resource):
 
 
 class _GitResource(Resource):
+    # TODO: This resource type is undocumented.
 
     SCHEMA = {
         "map": {
@@ -479,10 +502,10 @@ class _GitResource(Resource):
 
         super(_GitResource, self).__init__(descriptor)
 
-    def _get_default_name_value(self, descriptor):
+    def _get_default_name_value(self, descriptor: RawResourceDescriptor):
         return os.path.basename(descriptor.get("git", {}).get("url")).split(".", 1)[0]
 
-    def _copy_impl(self, target):
+    def _copy_impl(self, target: PathType) -> PathType:
         cmd = ["git", "clone", self.git.url, target]
         run_wrapper(cmd, False, f"Could not clone from {self.git.url}")
 
@@ -537,11 +560,11 @@ class _PlainResource(Resource):
 
         super(_PlainResource, self).__init__(descriptor)
 
-    def _copy_impl(self, target):
+    def _copy_impl(self, target: PathType) -> PathType:
         # First of all try to download the file using cacher if specified
         if config.get("common", "cache_url"):
             try:
-                self._download_file(None, target)
+                self._download_file(url=None, destination=target)
                 return target
             except Exception as e:
                 logger.debug(str(e))
@@ -610,18 +633,18 @@ class _ImageContentResource(Resource):
         }
     }
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor: RawResourceDescriptor):
         self.schema = _ImageContentResource.SCHEMA
 
         super(_ImageContentResource, self).__init__(descriptor)
 
-    def _get_default_name_value(self, descriptor):
+    def _get_default_name_value(self, descriptor: RawResourceDescriptor) -> str:
         """
         Default identifier is the file name of the resource inside of the image.
         """
         return os.path.basename(descriptor.get("path"))
 
-    def _copy_impl(self, target):
+    def _copy_impl(self, target: PathType) -> PathType:
         """
         For stage artifacts, there is nothing to copy, because the artifact is located
         in an image that should be built in earlier stage of the image build process.
@@ -661,18 +684,18 @@ class _PncResource(Resource):
         }
     }
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor: RawResourceDescriptor):
         self.schema = _PncResource.SCHEMA
 
         super(_PncResource, self).__init__(descriptor)
 
-    def _get_default_name_value(self, descriptor):
+    def _get_default_name_value(self, descriptor: RawResourceDescriptor) -> str:
         """
         Default identifier is the target file name.
         """
         return descriptor.get("target")
 
-    def _copy_impl(self, target):
+    def _copy_impl(self, target: PathType) -> PathType:
         """
         For PNC artifacts there is nothing to copy as the artifact is held remotely on PNC.
         """

--- a/cekit/descriptor/run.py
+++ b/cekit/descriptor/run.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import yaml
 
 from cekit.descriptor import Descriptor
@@ -24,14 +26,16 @@ class Run(Descriptor):
        descriptor - a yaml containing descriptor object
     """
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor: dict):
         self.schema = run_schema
         super(Run, self).__init__(descriptor)
         if "name" not in self._descriptor:
             self._descriptor["name"] = "run"
+        # TODO: skip_merging is ignored because we override merge...
         self.skip_merging = ["cmd", "entrypoint"]
 
-    def merge(self, descriptor):
+    # TODO: Justify or remove this alternate implementation of merge.
+    def merge(self, descriptor: Optional["Run"]) -> "Run":
         if not descriptor:
             return self
         for k2, v2 in descriptor.items():

--- a/cekit/descriptor/volume.py
+++ b/cekit/descriptor/volume.py
@@ -23,7 +23,7 @@ class Volume(Descriptor):
       descriptor - yaml file containing volume object
     """
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor: dict):
         self.schema = volume_schema
         super(Volume, self).__init__(descriptor)
         if "name" not in self._descriptor:

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -6,6 +6,7 @@ import platform
 import re
 import shutil
 import tempfile
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 from jinja2 import Environment, FileSystemLoader
@@ -13,11 +14,24 @@ from packaging.version import LegacyVersion
 from packaging.version import parse as parse_version
 
 from cekit.config import Config
-from cekit.descriptor import Env, Image, Label, Module, Overrides, Repository
+from cekit.descriptor import (
+    Env,
+    Image,
+    Label,
+    Module,
+    Modules,
+    Overrides,
+    Repository,
+    Resource,
+)
 from cekit.errors import CekitError
 from cekit.template_helper import TemplateHelper
-from cekit.tools import download_file, load_descriptor
+from cekit.tools import DependencyDefinition, Map, download_file, load_descriptor
+from cekit.types import PathType
 from cekit.version import __version__ as cekit_version
+
+if TYPE_CHECKING:
+    from cekit.descriptor.modules import Install
 
 LOGGER = logging.getLogger("cekit")
 CONFIG = Config()
@@ -43,15 +57,17 @@ class Generator(object):
 
     ODCS_HIDDEN_REPOS_FLAG = "include_unpublished_pulp_repos"
 
-    def __init__(self, descriptor_path, target, overrides):
-        self._descriptor_path = descriptor_path
-        self._overrides = []
-        self.target = target
+    def __init__(
+        self, descriptor_path: PathType, target: PathType, overrides: List[str]
+    ):
+        self._descriptor_path: PathType = descriptor_path
+        self._overrides: List[Overrides] = []
+        self.target: PathType = target
         self._fetch_repos = False
-        self._module_registry = ModuleRegistry()
-        self.image = None
-        self.builder_images = []
-        self.images = []
+        self._module_registry: ModuleRegistry = ModuleRegistry()
+        self.image: Optional[Image] = None
+        self.builder_images: List[Image] = []
+        self.images: List[Image] = []
 
         # If descriptor has been passed in from standard input its not a path so use current working directory
         if "-" == descriptor_path:
@@ -84,7 +100,7 @@ class Generator(object):
         LOGGER.info("Initializing image descriptor...")
 
     @staticmethod
-    def dependencies(params=None):
+    def dependencies(params: Map = None) -> DependencyDefinition:
         deps = {}
 
         deps["odcs-client"] = {
@@ -203,13 +219,13 @@ class Generator(object):
                 Label({"name": "summary", "value": description["value"]})
             )
 
-    def _modules(self):
+    def _modules(self) -> List["Modules"]:
         """
         Returns list of modules used in all builder images as well
         as the target image.
         """
 
-        modules = []
+        modules: List["Modules"] = []
 
         for image in self.images:
             if image.modules:
@@ -217,12 +233,12 @@ class Generator(object):
 
         return modules
 
-    def _module_repositories(self):
+    def _module_repositories(self) -> List["Resource"]:
         """
         Prepares list of all module repositories. This includes repositories
         defined in builder images as well as target image.
         """
-        repositories = []
+        repositories: List["Resource"] = []
 
         for module in self._modules():
             for repo in module.repositories:
@@ -239,7 +255,7 @@ class Generator(object):
 
         return repositories
 
-    def build_module_registry(self):
+    def build_module_registry(self) -> None:
         base_dir = os.path.join(self.target, "repo")
         if not os.path.exists(base_dir):
             os.makedirs(base_dir)
@@ -248,7 +264,7 @@ class Generator(object):
             repo.copy(base_dir)
             self.load_repository(os.path.join(base_dir, repo.target))
 
-    def load_repository(self, repo_dir):
+    def load_repository(self, repo_dir: str) -> None:
         for modules_dir, _, files in os.walk(repo_dir):
             if "module.yaml" in files:
 
@@ -268,13 +284,13 @@ class Generator(object):
                 )
                 self._module_registry.add_module(module)
 
-    def get_tags(self):
+    def get_tags(self) -> List[str]:
         return [
             "%s:%s" % (self.image["name"], self.image["version"]),
             "%s:latest" % self.image["name"],
         ]
 
-    def copy_modules(self):
+    def copy_modules(self) -> None:
         """Prepare module to be used for Dockerfile generation.
         This means:
 
@@ -282,7 +298,7 @@ class Generator(object):
 
         """
 
-        modules_to_install = []
+        modules_to_install: List["Install"] = []
 
         for module in self._modules():
             if module.install:
@@ -291,7 +307,7 @@ class Generator(object):
         target = os.path.join(self.target, "image", "modules")
 
         for module in modules_to_install:
-            module = self._module_registry.get_module(
+            module: "Module" = self._module_registry.get_module(
                 module.name, module.version, suppress_warnings=True
             )
             LOGGER.debug(
@@ -308,7 +324,7 @@ class Generator(object):
             # write out the module with any overrides
             module.write(os.path.join(dest, "module.yaml"))
 
-    def get_redhat_overrides(self):
+    def get_redhat_overrides(self) -> Overrides:
         class RedHatOverrides(Overrides):
             def __init__(self, generator):
                 super(RedHatOverrides, self).__init__({}, None)
@@ -348,7 +364,7 @@ class Generator(object):
 
         return RedHatOverrides(self)
 
-    def render_dockerfile(self):
+    def render_dockerfile(self) -> None:
         """Renders Dockerfile to $target/image/Dockerfile"""
         LOGGER.info("Rendering Dockerfile...")
 
@@ -371,7 +387,7 @@ class Generator(object):
             f.write(template.render(self.image).encode("utf-8"))
         LOGGER.debug("Dockerfile rendered")
 
-    def render_help(self):
+    def render_help(self) -> None:
         """
         If requested, renders image help page based on the image descriptor.
         It is generated to the $target/image/help.md file.
@@ -413,19 +429,20 @@ class Generator(object):
 
         LOGGER.debug("help.md rendered")
 
-    def prepare_repositories(self):
+    def prepare_repositories(self) -> None:
         """Prepare repositories for build time injection."""
         if "packages" not in self.image:
             return
 
+        # TODO: Replace gets with the equivalent actual properties
         if self.image.get("packages").get("content_sets"):
             LOGGER.warning(
                 "The image has ContentSets repositories specified, all other repositories are removed!"
             )
             self.image["packages"]["repositories"] = []
-        repos = self.image.get("packages").get("repositories", [])
+        repos: List[Repository] = self.image.get("packages").get("repositories", [])
 
-        injected_repos = []
+        injected_repos: List[Repository] = []
 
         for repo in repos:
             if self._handle_repository(repo):
@@ -449,7 +466,7 @@ class Generator(object):
         else:
             self.image["packages"]["set_url"] = injected_repos
 
-    def _prepare_content_sets(self, content_sets):
+    def _prepare_content_sets(self, content_sets: Repository):
         if not content_sets:
             return False
 
@@ -541,7 +558,7 @@ class Generator(object):
 
         return repofile
 
-    def _handle_repository(self, repo):
+    def _handle_repository(self, repo: Repository):
         """Process and prepares all v2 repositories.
 
         Args:
@@ -584,10 +601,10 @@ class Generator(object):
 
 class ModuleRegistry(object):
     def __init__(self):
-        self._modules = {}
-        self._defaults = {}
+        self._modules: Dict[str, Dict[str, Module]] = {}
+        self._defaults: Dict[str, str] = {}
 
-    def get_module(self, name, version=None, suppress_warnings=False):
+    def get_module(self, name, version: Any = None, suppress_warnings=False) -> Module:
         """
         Returns the module available in registry based on the name and version requested.
 
@@ -653,7 +670,7 @@ class ModuleRegistry(object):
 
         return module
 
-    def add_module(self, module):
+    def add_module(self, module: Module):
         """
         Adds provided module to registry.
 

--- a/cekit/generator/behave.py
+++ b/cekit/generator/behave.py
@@ -1,8 +1,13 @@
+from typing import List
+
 from cekit.generator.base import Generator
+from cekit.types import PathType
 
 
 class BehaveGenerator(Generator):
-    def __init__(self, descriptor_path, target, overrides):
+    def __init__(
+        self, descriptor_path: PathType, target: PathType, overrides: List[str]
+    ):
         super(BehaveGenerator, self).__init__(descriptor_path, target, overrides)
 
     def prepare_artifacts(self):

--- a/cekit/generator/docker.py
+++ b/cekit/generator/docker.py
@@ -1,15 +1,19 @@
 import logging
 import os
+from typing import List
 
 from cekit.config import Config
 from cekit.generator.base import Generator
+from cekit.types import PathType
 
 logger = logging.getLogger("cekit")
 config = Config()
 
 
 class DockerGenerator(Generator):
-    def __init__(self, descriptor_path, target, overrides):
+    def __init__(
+        self, descriptor_path: PathType, target: PathType, overrides: List[str]
+    ):
         super(DockerGenerator, self).__init__(descriptor_path, target, overrides)
         self._fetch_repos = True
 

--- a/cekit/generator/osbs.py
+++ b/cekit/generator/osbs.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 from collections import OrderedDict
 from contextlib import closing
-from typing import Dict, List
+from typing import TYPE_CHECKING, Callable, Dict, List
 from urllib.parse import urlparse
 
 import yaml
@@ -21,13 +21,19 @@ from cekit.descriptor.resource import (
 from cekit.errors import CekitError
 from cekit.generator.base import Generator
 from cekit.tools import copy_recursively, get_brew_url
+from cekit.types import PathType
+
+if TYPE_CHECKING:
+    from cekit.descriptor import Repository
 
 logger = logging.getLogger("cekit")
 config = Config()
 
 
 class OSBSGenerator(Generator):
-    def __init__(self, descriptor_path, target, overrides):
+    def __init__(
+        self, descriptor_path: PathType, target: PathType, overrides: List[str]
+    ):
         self._wipe = True
         super(OSBSGenerator, self).__init__(descriptor_path, target, overrides)
 
@@ -35,6 +41,7 @@ class OSBSGenerator(Generator):
         super(OSBSGenerator, self).init()
 
         self._prepare_osbs_config_file(yaml.safe_dump, "container.yaml")
+        # TODO: Why do we use file.write here and yaml.dump above?
         self._prepare_osbs_config_file(
             lambda contents, file, **kwargs: file.write(contents), "gating.yaml"
         )
@@ -52,7 +59,7 @@ class OSBSGenerator(Generator):
         )
         super(OSBSGenerator, self).generate()
 
-    def _prepare_content_sets(self, content_sets):
+    def _prepare_content_sets(self, content_sets: "Repository"):
         content_sets_f = os.path.join(self.target, "image", "content_sets.yml")
 
         if not os.path.exists(os.path.dirname(content_sets_f)):
@@ -61,11 +68,14 @@ class OSBSGenerator(Generator):
         with open(content_sets_f, "w") as _file:
             yaml.safe_dump(content_sets, _file, default_flow_style=False)
 
-    def _prepare_osbs_config_file(self, writer, config_file):
+    def _prepare_osbs_config_file(
+        self, writer: Callable[..., None], config_file: PathType
+    ) -> None:
         config_path = os.path.join(self.target, "image", config_file)
         config_name = config_file.split(".")[0]
         all_configs = []
 
+        # TODO: Replace `.get` with actual type-safe getters.
         if self.image.get("osbs", {}).get("configuration", {}).get(config_name):
             all_configs.append(
                 self.image.get("osbs", {}).get("configuration", {}).get(config_name)
@@ -98,7 +108,7 @@ class OSBSGenerator(Generator):
         with open(config_path, "w") as _file:
             writer(all_configs[0], _file, default_flow_style=False)
 
-    def prepare_artifacts(self):
+    def prepare_artifacts(self) -> None:
         """Goes through artifacts section of image descriptor
         and fetches all of them
         """

--- a/cekit/log.py
+++ b/cekit/log.py
@@ -13,18 +13,18 @@ except ImportError:
 # Source: http://stackoverflow.com/questions/1383254/logging-streamhandler-and-standard-streams
 # Adjusted
 class SingleLevelFilter(logging.Filter):
-    def __init__(self, passlevel, reject):
+    def __init__(self, passlevel: int, reject: bool) -> None:
         self.passlevel = passlevel
         self.reject = reject
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         if self.reject:
             return record.levelno > self.passlevel
         else:
             return record.levelno <= self.passlevel
 
 
-def setup_logging(color=True):
+def setup_logging(color: bool = True) -> None:
     handler_out = logging.StreamHandler(sys.stdout)
     handler_err = logging.StreamHandler(sys.stderr)
 

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -5,7 +5,7 @@ import shutil
 import ssl
 import subprocess
 import sys
-from typing import Mapping, Sequence
+from typing import Any, Mapping, Optional, Sequence
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
@@ -15,6 +15,7 @@ from yaml.representer import SafeRepresenter
 
 from cekit.config import Config
 from cekit.errors import CekitError
+from cekit.types import DependencyDefinition, PathType
 
 logger = logging.getLogger("cekit")
 config = Config()
@@ -95,6 +96,7 @@ def download_file(url: str, destination: str) -> None:
 
 
 def load_descriptor(descriptor: str) -> dict:
+    # TODO: The docstring mentions validation, but this doesn't appear to validate.
     """parses descriptor and validate it against requested schema type
 
     Args:
@@ -132,7 +134,7 @@ def load_descriptor(descriptor: str) -> dict:
     return data
 
 
-def decision(question):
+def decision(question: str) -> bool:
     """Asks user for a question returning True/False answered"""
     return click.confirm(question, show_default=True)
 
@@ -284,7 +286,9 @@ def get_brew_url(md5: str) -> str:
     )
 
 
-def copy_recursively(source_directory: str, destination_directory: str) -> None:
+def copy_recursively(
+    source_directory: PathType, destination_directory: PathType
+) -> None:
     """
     Copies contents of a directory to selected target location (also a directory).
     the specific source file to destination.
@@ -375,7 +379,7 @@ def run_wrapper(
 class Chdir(object):
     """Context manager for changing the current working directory"""
 
-    def __init__(self, new_path):
+    def __init__(self, new_path: PathType):
         self.newPath = os.path.expanduser(new_path)
         self.savedPath = None
 
@@ -402,7 +406,7 @@ class DependencyHandler(object):
     # Format is defined below, in the handle_dependencies() method
     EXTERNAL_CORE_DEPENDENCIES = {"git": {"package": "git", "executable": "git"}}
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.os_release = {}
         self.platform = None
         self.version = None
@@ -456,7 +460,7 @@ class DependencyHandler(object):
             )
         )
 
-    def _handle_dependencies(self, dependencies: dict) -> None:
+    def _handle_dependencies(self, dependencies: DependencyDefinition) -> None:
         """
         The dependencies provided is expected to be a dict in following format:
 
@@ -544,7 +548,7 @@ class DependencyHandler(object):
         logger.debug("All dependencies provided!")
 
     # noinspection PyMethodMayBeStatic
-    def _check_for_library(self, library):
+    def _check_for_library(self, library: str) -> bool:
         library_found = False
 
         if importlib.util.find_spec(library):
@@ -552,7 +556,9 @@ class DependencyHandler(object):
 
         return library_found
 
-    def _check_for_executable(self, dependency, executable, package=None):
+    def _check_for_executable(
+        self, dependency: str, executable: str, package: None = None
+    ) -> Optional[bool]:
         if os.path.isabs(executable):
             if self._is_program(executable):
                 return True
@@ -586,7 +592,7 @@ class DependencyHandler(object):
 
         raise CekitError(msg)
 
-    def _is_program(self, path):
+    def _is_program(self, path: str) -> bool:
         if (
             os.path.exists(path)
             and os.access(path, os.F_OK | os.X_OK)
@@ -596,7 +602,7 @@ class DependencyHandler(object):
 
         return False
 
-    def handle_core_dependencies(self):
+    def handle_core_dependencies(self) -> None:
         self._handle_dependencies(DependencyHandler.EXTERNAL_CORE_DEPENDENCIES)
 
         try:
@@ -614,11 +620,11 @@ class DependencyHandler(object):
         except ImportError:
             pass
 
-    def handle(self, o, params) -> None:
+    # TODO: Use either structural typing or a base class to make this logic simpler.
+    def handle(self, o: Any, params: Map) -> None:
         """
         Handles dependencies from selected object. If the object has 'dependencies' method,
         it will be called to retrieve a set of dependencies to check for.
-        :param params:
         """
 
         if not o:

--- a/cekit/types.py
+++ b/cekit/types.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, List, TypeVar, Union
+
+_T = TypeVar("_T")
+
+# TODO: Once we drop support for 3.9, we should change these to TypeAliases, PEP613
+
+ContentSetType = Dict[str, List[str]]
+
+DependencyDefinition = Dict[str, Dict[str, Union[str, dict]]]
+
+# Name to clarify when we use strings as paths.
+PathType = str
+
+RawDescriptor = Dict[str, Any]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -174,6 +174,7 @@ class DistGitMock(object):
 def create_builder_object(
     mocker, builder, params, common_params={"target": "something"}
 ):
+    # TODO: Remove mutable default argument
     if "docker" == builder:
         from cekit.builders.docker_builder import DockerBuilder as BuilderImpl
     elif "osbs" == builder:


### PR DESCRIPTION
To ease future development, I've gone ahead and added type hints to the vast majority of the code base. With one exception, all changes are to add type hints only—no code changes.

The exception is that I have made a small change to the code in `descriptor/image.py`, where `self._image_overrides` is now set to a named tuple instead of a dictionary (otherwise I was unable to follow the types through this dictionary).

A couple of call outs:
- I've added a `PathType` which is just an alias for `str`, but hopefully makes it more obvious when we're using a string as a path as opposed to something else. I may not have picked up on all cases where `str` is a path.
- To avoid introducing any circular imports (now or down the road) purely because of type hinting, where the types come from a module that was not already imported, they are protected by `if TYPE_CHECKING` so they are not imported at runtime.
- There are a few places where the code could potentially benefit from structural typing (PEP 544, added Python 3.8). The dependency handler is one such place (though I think we should actually add a `HasDependencies` mixin type).
- Most of the types in `cekit.types` would be better expressed as Type Aliases (PEP 613, added in Python 3.10). It's a few years before we'll be not needing Python 3.9, though. Some of these could also be better addressed by creating domain specific types, rather than using POPOs.
- Regarding types that must be enclosed in quotes: PEP 563 (Python 3.7) would enable us to drop the quotes everywhere by adding a `from __future__` import, however, it looks like instead waiting for PEP 649 would keep the code cleaner, so I have stuck with the original approach.
- The names of descriptors are not (currently) required to be strings, though allowing anything here makes things more complicated. We should consider normalising on strings.
- Maybe I'm missing something, but the osbs builder appears to have some serious type errors. I'm surprised this code works at all (maybe it isn't covered by tests?)
- There are a few places where we replace instance variables with things of different type. So the type of something depends on when you access it. IMHO this is a no-no and very prone to errors (possibly explains what is going on with osbs mentioned above, though if it does, I don't see it.) We should consider refactoring this. Specifically, currently, the things under the `Descriptor` hierarchy serve two purposes: represent the descriptor loaded from disk, and represent the internal view of these things after "hydrating". 
- I have not looked at adding or checking types in the test code at all.

Along the way, I noticed a number of things in the code. I have added TODO comments for those things, and if time allows I may raise a separate PR to address most of those.