### PR TITLE
[ISSUE-830] restrict packaging version to <22.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             pyenv install -s 3.7.13
             pyenv install -s 3.10.3
             pyenv local 3.7.13 3.10.3
-            pip install tox
+            pip install "tox<4.0.0"
       - run: git config --global user.email "ci@dummy.com" && git config --global user.name "John Doe"
       - run: |
          if [[ "${CIRCLE_NODE_INDEX}" == 1 ]]; then

--- a/.github/workflows/cekit.yml
+++ b/.github/workflows/cekit.yml
@@ -44,7 +44,7 @@ jobs:
         docker info
         podman version
         podman info
-        pip install tox
+        pip install "tox<4.0.0"
         git config --global user.email "ci@dummy.com" && git config --global user.name "John Doe"
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         mkdir -p $HOME/.local/bin
@@ -53,7 +53,7 @@ jobs:
     - name: Setup MacOS
       if: startsWith(matrix.os,'macos')
       run: |
-        pip install tox
+        pip install "tox<4.0.0"
         brew install podman
         podman machine init
         podman machine start

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ Jinja2>=2.7
 pykwalify>=1.6.0
 colorlog>=2.10.0
 click>=6.7
-packaging>=19.0
+packaging>=19.0,<22.0
 odcs>=0.2.10


### PR DESCRIPTION
Fix https://github.com/cekit/cekit/issues/830

Running CEKit with `22.x` packaging version will throw the following error:
```
    from packaging.version import LegacyVersion
ImportError: cannot import name 'LegacyVersion' from 'packaging.version' (/home/alampare/miniconda3/envs/cekit-4.4/lib/python3.10/site-packages/packaging/version.py)
```

This was introduced since `packaging=22.0` [1]:

```
Remove LegacySpecifier and LegacyVersion (issue:`407`)
```

The fastest solution would be to restrict the `packaging` version to `<22.0` in the `requirements.txt`

[1] https://github.com/pypa/packaging/blob/main/CHANGELOG.rst#220---2022-12-07 