### PR TITLE
Add Python 3.12 to CI tests

### DIFF
--- a/.github/workflows/cekit.yml
+++ b/.github/workflows/cekit.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
         os: [macos-latest, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,6 +32,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Setup Linux
       if: startsWith(matrix.os,'ubuntu')
       run: |
@@ -44,7 +45,7 @@ jobs:
         docker info
         podman version
         podman info
-        pip install "tox<4.0.0"
+        pip install "tox<4.0.0" setuptools
         git config --global user.email "ci@dummy.com" && git config --global user.name "John Doe"
         echo "$HOME/bin" >> $GITHUB_PATH
         mkdir $HOME/bin
@@ -54,7 +55,7 @@ jobs:
     - name: Setup MacOS
       if: startsWith(matrix.os,'macos')
       run: |
-        pip install "tox<4.0.0"
+        pip install "tox<4.0.0" setuptools
         # Update qemu for https://github.com/containers/podman/issues/19708 / https://github.com/Homebrew/homebrew-core/issues/140244
         brew update
         brew upgrade qemu

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ test-py310: prepare
 test-py311: prepare
 	tox -e py311 -- tests
 
+test-py312: prepare
+	tox -e py312 -- tests
+
 clean:
 	@find . -name "*.pyc" -exec rm -rf {} \;
 	@rm -rf target

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311
+envlist = py36,py37,py38,py39,py310,py311,py312
 
 [testenv]
 deps=pipenv


### PR DESCRIPTION
Python 3.12 release schedule: https://peps.python.org/pep-0693/
