### PR TITLE
Add .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+        threshold: 1%


### PR DESCRIPTION
Avoid too many codecoverage warnings when submitting PRs.