### PR TITLE
test: behave: add --steps-ref command

### DIFF
--- a/cekit/cli.py
+++ b/cekit/cli.py
@@ -13,7 +13,7 @@ from cekit.config import Config, default_work_dir
 from cekit.errors import CekitError
 from cekit.log import setup_logging
 from cekit.tools import Map
-from cekit.version import __version__
+from cekit.version import __version__, schema_version
 
 if TYPE_CHECKING:
     from cekit.builder import Command
@@ -352,6 +352,12 @@ def test(image, overrides):
     default="https://github.com/cekit/behave-test-steps.git",
     show_default=True,
 )
+@click.option(
+    "--steps-ref",
+    help="Behave steps library reference (branch or tag)",
+    default="v%s" % schema_version,
+    show_default=True,
+)
 @click.option("--wip", help="Run test scenarios tagged with @wip only.", is_flag=True)
 @click.option("--include-re", help="Run only those features which match this regex")
 @click.option("--exclude-re", help="Do not run those features which match this regex")
@@ -362,7 +368,7 @@ def test(image, overrides):
     multiple=True,
 )
 @click.pass_context
-def test_behave(ctx, steps_url, wip, names, include_re, exclude_re):
+def test_behave(ctx, steps_url, steps_ref, wip, names, include_re, exclude_re):
     """
     DESCRIPTION
 

--- a/cekit/test/behave_tester.py
+++ b/cekit/test/behave_tester.py
@@ -5,7 +5,6 @@ from cekit.builder import Command
 from cekit.generator.behave import BehaveGenerator
 from cekit.test.behave_runner import BehaveTestRunner
 from cekit.test.collector import BehaveTestCollector
-from cekit.version import schema_version
 
 LOGGER = logging.getLogger("cekit")
 
@@ -44,10 +43,8 @@ class BehaveTester(Command):
 
         self.generator.generate()
 
-        # The branch to clone is determined by the schema_version in the descriptor prefixed with `v`
-        # It defaults to the CEKIt current schema_version.
         self.collected = self.test_collector.collect(
-            self.generator.image.get("schema_version", schema_version),
+            self.params.steps_ref,
             self.params.steps_url,
         )
 

--- a/cekit/test/collector.py
+++ b/cekit/test/collector.py
@@ -41,7 +41,7 @@ class BehaveTestCollector(object):
 
     def _fetch_steps(self, version, url):
         """Method fetches common steps"""
-        logger.info("Fetching common steps from '{}'.".format(url))
+        logger.info("Fetching common steps from '{}', ref '{}'.".format(url, version))
         cmd = [
             "git",
             "clone",
@@ -50,7 +50,7 @@ class BehaveTestCollector(object):
             url,
             self.test_dir,
             "-b",
-            "v%s" % version,
+            "%s" % version,
         ]
         run_wrapper(cmd, False, f"Could not fetch steps from {url}")
 

--- a/docs/handbook/testing/behave.rst
+++ b/docs/handbook/testing/behave.rst
@@ -122,6 +122,7 @@ Options
 
 * ``--wip`` -- Only run tests tagged with the ``@wip`` tag.
 * ``--steps-url`` -- A git repository url containing `steps <https://pythonhosted.org/behave/tutorial.html#python-step-implementations>`_ for tests.
+* ``--steps-ref`` -- A reference (branch or tag) in the steps repository to check out
 * ``--name`` -- *Scenario* name to be executed
 * ``--include-re`` -- Regex of feature files which will be executed only
 * ``--exclude-re`` -- Regex of feature files which will not be executed

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -286,6 +286,7 @@ def _get_class_by_name(clazz):
                 "overrides": (),
                 "image": "image:1.0",
                 "steps_url": "https://github.com/cekit/behave-test-steps.git",
+                "steps_ref": "v1",
                 "wip": False,
                 "include_re": None,
                 "exclude_re": None,


### PR DESCRIPTION
Prior to this commit, when cloning the behave-test-steps URI, CEKIt looked up the schema_version set in the descriptor in use, defaulting to cekit.version.schema_version (which was usually 1); prefixed a 'v' to get 'v1' and always switched to that ref ('v1').

Instead, Add a click.option such that we have self.params.steps_ref used as the reference to check out, defaulting to 'v' + cekit.version.schema_version.

Fixes #876.