### PR TITLE
Fixes for Python 3.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,6 +27,7 @@ PyYAML = ">=3.10"
 Jinja2 = ">=2.7"
 click = ">=6.7"
 odcs = ">=0.2.10"
+"ruamel.yaml" = {version="<=0.18.3",python_version="<3.7"}
 
 [requires]
 python_version = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ colorlog>=2.10.0
 click>=6.7
 packaging>=19.0
 odcs>=0.2.10
+ruamel.yaml<=0.18.3 ; python_version<'3.7'


### PR DESCRIPTION
CEKit requires pykwalify which implicitly brings in ruamel. In ruamel 0.18.4 ( https://sourceforge.net/p/ruamel-yaml/code/ci/08d87cada1f6e5fedde079b55536061e4fe246a0/#diff-7 ) has `from __future__ import annotations` which is only supported in Python 3.7 so this, for Python 3.6, uses an earlier version of ruamel.