### PR TITLE
Remove support for older docker library. 

### DIFF
--- a/cekit/builders/docker_builder.py
+++ b/cekit/builders/docker_builder.py
@@ -32,6 +32,7 @@ except ImportError:
     pass
 
 ANSI_ESCAPE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+DOCKER_API_VERSION = "1.35"
 
 
 class DockerBuilder(Builder):
@@ -194,7 +195,7 @@ class DockerBuilder(Builder):
                 )
             )
 
-        params = {"version": docker.constants.DEFAULT_DOCKER_API_VERSION}
+        params = {"version": DOCKER_API_VERSION}
         params.update(docker.utils.kwargs_from_env())
         params["timeout"] = timeout
 

--- a/cekit/builders/docker_builder.py
+++ b/cekit/builders/docker_builder.py
@@ -20,7 +20,6 @@ except ImportError:
 try:
     # Docker Python library, the new one
     import docker
-    from docker.api.client import APIClient as APIClientClass
 except ImportError:
     pass
 
@@ -29,13 +28,6 @@ try:
     # so that the dependency mechanism can kick in and require the docker library
     # first which will pull requests
     import requests
-except ImportError:
-    pass
-
-try:
-    # Docker Python library, the old one
-    import docker  # noqa: F811
-    from docker.client import Client as APIClientClass  # noqa: F811
 except ImportError:
     pass
 
@@ -202,12 +194,12 @@ class DockerBuilder(Builder):
                 )
             )
 
-        params = {"version": "1.35"}
+        params = {"version": docker.constants.DEFAULT_DOCKER_API_VERSION}
         params.update(docker.utils.kwargs_from_env())
         params["timeout"] = timeout
 
         try:
-            client = APIClientClass(**params)
+            client = docker.APIClient(**params)
         except docker.errors.DockerException as e:
             LOGGER.error(
                 "Could not create Docker client, please make sure that you "

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -793,7 +793,7 @@ def test_osbs_dist_git_sync_NOT_called_when_dry_run_set(mocker, tmpdir):
 def test_docker_build_default_tags(mocker):
     builder = DockerBuilder(Map({"target": "something"}))
 
-    docker_client_class = mocker.patch("cekit.builders.docker_builder.APIClientClass")
+    docker_client_class = mocker.patch("cekit.builders.docker_builder.docker.APIClient")
     docker_client = docker_client_class.return_value
     mock_generator = mocker.patch.object(builder, "generator")
     mock_generator.get_tags.return_value = ["image/test:1.0", "image/test:latest"]
@@ -822,7 +822,7 @@ def test_docker_squashing_enabled(mocker):
     assert builder.params.no_squash is None
     assert builder.params.tags == ["foo", "bar"]
 
-    docker_client_class = mocker.patch("cekit.builders.docker_builder.APIClientClass")
+    docker_client_class = mocker.patch("cekit.builders.docker_builder.docker.APIClient")
     docker_client = docker_client_class.return_value
     mocker.patch.object(builder, "_build_with_docker")
     mocker.patch.object(builder, "_squash")
@@ -845,7 +845,7 @@ def test_docker_squashing_disabled(mocker):
 
     assert builder.params.no_squash is True
 
-    docker_client_class = mocker.patch("cekit.builders.docker_builder.APIClientClass")
+    docker_client_class = mocker.patch("cekit.builders.docker_builder.docker.APIClient")
     docker_client = docker_client_class.return_value
     mocker.patch.object(builder, "_build_with_docker")
     mocker.patch.object(builder, "_squash")
@@ -866,7 +866,7 @@ def test_docker_squashing_parameters(mocker):
     # None is fine here, default values for params are tested in different place
     assert builder.params.no_squash is None
 
-    docker_client_class = mocker.patch("cekit.builders.docker_builder.APIClientClass")
+    docker_client_class = mocker.patch("cekit.builders.docker_builder.docker.APIClient")
     squash_class = mocker.patch("cekit.builders.docker_builder.Squash")
     squash = squash_class.return_value
     docker_client = docker_client_class.return_value

--- a/tests/test_unit_builder_docker.py
+++ b/tests/test_unit_builder_docker.py
@@ -94,7 +94,7 @@ def test_docker_client_build(mocker, caplog):
 
     squash_class = mocker.patch("cekit.builders.docker_builder.Squash")
     squash = squash_class.return_value
-    docker_client_class = mocker.patch("cekit.builders.docker_builder.APIClientClass")
+    docker_client_class = mocker.patch("cekit.builders.docker_builder.docker.APIClient")
     docker_client = docker_client_class.return_value
     docker_client_build = mocker.patch.object(
         docker_client, "build", return_value=docker_success_output
@@ -128,7 +128,7 @@ def test_docker_client_build_platform(mocker, caplog):
     caplog.set_level(logging.DEBUG, logger="cekit")
 
     mocker.patch("cekit.builders.docker_builder.Squash")
-    docker_client_class = mocker.patch("cekit.builders.docker_builder.APIClientClass")
+    docker_client_class = mocker.patch("cekit.builders.docker_builder.docker.APIClient")
     docker_client = docker_client_class.return_value
     docker_client_build = mocker.patch.object(
         docker_client, "build", return_value=docker_success_output
@@ -167,7 +167,7 @@ def test_docker_client_build_with_failure(mocker, caplog):
         Map(merge_dicts({"target": "something"}, {"tags": ["foo", "bar"]}))
     )
 
-    docker_client_class = mocker.patch("cekit.builders.docker_builder.APIClientClass")
+    docker_client_class = mocker.patch("cekit.builders.docker_builder.docker.APIClient")
     squash_class = mocker.patch("cekit.builders.docker_builder.Squash")
     squash = squash_class.return_value
     docker_client = docker_client_class.return_value


### PR DESCRIPTION
The old library dates from the days it was called "docker-py", the last release (1.10.6) for which was November 2016 (See https://docker-py.readthedocs.io/en/stable/change-log.html#id156 ) 

Originally I considered locking the version to the _current_ version of docker python library (`constants.DEFAULT_DOCKER_API_VERSION`) but it may move too quick and therefore we switched to using our own constant that the behave suite can also reuse.