### PR TITLE
Clean package management cache when not using squash

### DIFF
--- a/cekit/builder.py
+++ b/cekit/builder.py
@@ -102,6 +102,7 @@ class Builder(Command):
             self.params.target,
             container_file,
             self.params.overrides,
+            self.params.no_squash,
         )
 
         if CONFIG.get("common", "redhat"):

--- a/cekit/builders/oci_builder.py
+++ b/cekit/builders/oci_builder.py
@@ -48,7 +48,15 @@ class OCIBuilder(Builder):
 
         cmd.append(os.path.join(self.target, "image"))
 
-        run_wrapper(cmd, False, f"Could not run {build_type} {cmd}")
+        capture: bool = False
+        if LOGGER.isEnabledFor(logging.DEBUG):
+            # Normally we'll just let output print to stdout/stderr. If verbose(debug) is enabled
+            # then we'll capture it but log it as well. This is useful for tests verifying the output.
+            capture = True
+        result = run_wrapper(cmd, capture, f"Could not run {build_type} {cmd}")
+        if result.stdout is not None:
+            LOGGER.debug(result.stdout)
+            LOGGER.debug("\n")
 
         LOGGER.info(
             f"Image built and available under following tags: {', '.join(tags)}"

--- a/cekit/generator/base.py
+++ b/cekit/generator/base.py
@@ -71,6 +71,7 @@ class Generator(object):
         target: PathType,
         container_file: str,
         overrides: List[str],
+        no_squash: bool,
     ):
         self._descriptor_path: PathType = descriptor_path
         self._overrides: List[Overrides] = []
@@ -81,6 +82,7 @@ class Generator(object):
         self.builder_images: List[Image] = []
         self.images: List[Image] = []
         self.container_file: str = container_file
+        self.no_squash: bool = no_squash
 
         # If descriptor has been passed in from standard input its not a path so use current working directory
         if "-" == descriptor_path:
@@ -383,6 +385,7 @@ class Generator(object):
         env.globals["helper"] = TemplateHelper(self._module_registry)
         env.globals["image"] = self.image
         env.globals["builders"] = self.builder_images
+        env.globals["no_squash"] = self.no_squash
 
         template = env.get_template(os.path.basename(template_file))
 

--- a/cekit/generator/behave.py
+++ b/cekit/generator/behave.py
@@ -11,9 +11,10 @@ class BehaveGenerator(Generator):
         target: PathType,
         container_file: str,
         overrides: List[str],
+        no_squash: bool,
     ):
         super(BehaveGenerator, self).__init__(
-            descriptor_path, target, container_file, overrides
+            descriptor_path, target, container_file, overrides, no_squash
         )
 
     def prepare_artifacts(self):

--- a/cekit/generator/docker.py
+++ b/cekit/generator/docker.py
@@ -17,9 +17,10 @@ class DockerGenerator(Generator):
         target: PathType,
         container_file: str,
         overrides: List[str],
+        no_squash: bool,
     ):
         super(DockerGenerator, self).__init__(
-            descriptor_path, target, container_file, overrides
+            descriptor_path, target, container_file, overrides, no_squash
         )
         self._fetch_repos = True
 

--- a/cekit/generator/osbs.py
+++ b/cekit/generator/osbs.py
@@ -37,10 +37,11 @@ class OSBSGenerator(Generator):
         target: PathType,
         container_file: str,
         overrides: List[str],
+        no_squash: bool,
     ):
         self._wipe = True
         super(OSBSGenerator, self).__init__(
-            descriptor_path, target, container_file, overrides
+            descriptor_path, target, container_file, overrides, no_squash
         )
 
     def init(self):

--- a/cekit/template_helper.py
+++ b/cekit/template_helper.py
@@ -176,20 +176,25 @@ class TemplateHelper(object):
         ):
             return True
 
-    def package_manager_clean_and_query(self, pkg_mgr):
+    def package_manager_query(self, pkg_mgr):
         if "apk" in pkg_mgr:
             return "apk info -e"
         elif "apt-get" in pkg_mgr:
             return "dpkg-query --list"
         else:
-            result = ""
-            if "microdnf" in pkg_mgr:
-                result += "microdnf clean all && "
-            result += "rpm -q"
-            return result
+            return "rpm -q"
 
     def package_manager_remove(self, pkg_mgr):
         if "apk" in pkg_mgr:
             return "del"
         else:
             return "remove -y"
+
+    def package_manager_clean(self, pkg_mgr):
+        if "apk" in pkg_mgr:
+            # Cache is not enabled by default so there is nothing to clean
+            return ":"
+        elif "apt-get" in pkg_mgr:
+            return pkg_mgr + " clean"
+        else:
+            return pkg_mgr + " clean all"

--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -12,7 +12,7 @@ repos/{{ repo.filename }} \
  # Removes packages using specified package manager.
  #}
 {%- macro pkg_remove(pkg_manager, pkg_manager_flags, packages) -%}
-{{ pkg_manager }} {{ helper.package_manager_flags(pkg_manager, pkg_manager_flags) }} {{ helper.package_manager_remove(pkg_manager) }} {%- for package in packages %} {{ package }}{% endfor %}
+{{ pkg_manager }} {{ helper.package_manager_flags(pkg_manager, pkg_manager_flags) }} {{ helper.package_manager_remove(pkg_manager) }} {%- for package in packages %} {{ package }}{% endfor %} \
 {%- endmacro -%}
 
 {#
@@ -20,7 +20,7 @@ repos/{{ repo.filename }} \
  #}
 {%- macro pkg_install(pkg_manager, pkg_manager_flags, packages) -%}
 {{ pkg_manager }} {{ helper.package_manager_flags(pkg_manager, pkg_manager_flags) }} {{ helper.package_manager_install(pkg_manager) }} {%- for package in packages %} {{ package }}{% endfor %} \
-            && {{ helper.package_manager_clean_and_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %}
+            && {{ helper.package_manager_clean_and_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %} \
 {%- endmacro -%}
 
 {#
@@ -28,7 +28,7 @@ repos/{{ repo.filename }} \
  #}
 {%- macro pkg_reinstall(pkg_manager, pkg_manager_flags, packages) -%}
 {{ pkg_manager }} {{ helper.package_manager_flags(pkg_manager, pkg_manager_flags) }} {{ helper.package_manager_reinstall(pkg_manager) }} {%- for package in packages %} {{ package }}{% endfor %} \
-            && {{ helper.package_manager_clean_and_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %}
+            && {{ helper.package_manager_clean_and_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %} \
 {%- endmacro -%}
 
 
@@ -99,18 +99,35 @@ repos/{{ repo.filename }} \
         {% if module.packages and module.packages.remove or module.packages.install or module.packages.reinstall %}
         # Switch to 'root' user for package management for '{{ module.name }}' {{ module_type }} defined packages
         USER root
+        {#
+         # Ideally we would use heredoc but its not available in all versions so use continuation lines.
+         #}
+        RUN : \
         {% if module.packages and module.packages.remove %}
         # Remove packages defined in the '{{ module.name }}' {{ module_type }}
-        RUN {{ pkg_remove(parent_image.packages.manager, parent_image.packages.manager_flags, module.packages.remove) }}
+        && {{ pkg_remove(parent_image.packages.manager, parent_image.packages.manager_flags, module.packages.remove) }}
         {% endif -%}
         {% if module.packages and module.packages.install %}
         # Install packages defined in the '{{ module.name }}' {{ module_type }}
-        RUN {{ pkg_install(parent_image.packages.manager, parent_image.packages.manager_flags, module.packages.install) }}
+        && {{ pkg_install(parent_image.packages.manager, parent_image.packages.manager_flags, module.packages.install) }}
         {% endif -%}
         {% if module.packages and module.packages.reinstall %}
         # Reinstall packages defined in the '{{ module.name }}' {{ module_type }}
-        RUN {{ pkg_reinstall(parent_image.packages.manager, parent_image.packages.manager_flags, module.packages.reinstall) }}
+        && {{ pkg_reinstall(parent_image.packages.manager, parent_image.packages.manager_flags, module.packages.reinstall) }}
         {% endif -%}
+        {#
+         # Only if we're not using CEKit squashing do we clear the metadata here.
+         #}
+        {% if no_squash %}
+        {% if helper.package_manager_cleanup(image) %}
+        # Clear package manager metadata
+        && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf" \
+        {% endif -%}
+        {% endif -%}
+        {#
+         # The : noop is only to complete any prior continuation lines.
+         #}
+        && :
 
         {% endif -%}
         {% if module_type == 'module' %}
@@ -239,9 +256,11 @@ repos/{{ repo.filename }} \
     {#
      # Clears repository cache.
      #}
+    {% if not no_squash %}
     {% if helper.package_manager_cleanup(image) %}
     # Clear package manager metadata
     RUN rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"
+    {% endif -%}
     {% endif -%}
 
     {#

--- a/cekit/templates/template.jinja
+++ b/cekit/templates/template.jinja
@@ -20,7 +20,7 @@ repos/{{ repo.filename }} \
  #}
 {%- macro pkg_install(pkg_manager, pkg_manager_flags, packages) -%}
 {{ pkg_manager }} {{ helper.package_manager_flags(pkg_manager, pkg_manager_flags) }} {{ helper.package_manager_install(pkg_manager) }} {%- for package in packages %} {{ package }}{% endfor %} \
-            && {{ helper.package_manager_clean_and_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %} \
+            && {{ helper.package_manager_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %} \
 {%- endmacro -%}
 
 {#
@@ -28,9 +28,16 @@ repos/{{ repo.filename }} \
  #}
 {%- macro pkg_reinstall(pkg_manager, pkg_manager_flags, packages) -%}
 {{ pkg_manager }} {{ helper.package_manager_flags(pkg_manager, pkg_manager_flags) }} {{ helper.package_manager_reinstall(pkg_manager) }} {%- for package in packages %} {{ package }}{% endfor %} \
-            && {{ helper.package_manager_clean_and_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %} \
+            && {{ helper.package_manager_query(pkg_manager) }}{% for package in packages %} {{ package.split('=')[0] }}{% endfor %} \
 {%- endmacro -%}
 
+
+{#
+ # Cleans up package manager.
+ #}
+{%- macro pkg_cleanup(pkg_manager) -%}
+    {{ helper.package_manager_clean(pkg_manager) }} \
+{%- endmacro -%}
 
 {#
  # Handle processing ARGS
@@ -121,6 +128,7 @@ repos/{{ repo.filename }} \
         {% if no_squash %}
         {% if helper.package_manager_cleanup(image) %}
         # Clear package manager metadata
+        && {{ pkg_cleanup(parent_image.packages.manager) }}
         && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf" \
         {% endif -%}
         {% endif -%}
@@ -259,7 +267,8 @@ repos/{{ repo.filename }} \
     {% if not no_squash %}
     {% if helper.package_manager_cleanup(image) %}
     # Clear package manager metadata
-    RUN rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"
+    RUN {{ pkg_cleanup(image.packages.manager) }}
+    && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"
     {% endif -%}
     {% endif -%}
 

--- a/cekit/test/behave_tester.py
+++ b/cekit/test/behave_tester.py
@@ -33,6 +33,7 @@ class BehaveTester(Command):
             self.params.target,
             "Dockerfile",
             self.params.overrides,
+            False,
         )
 
         # Handle dependencies for selected generator, if any

--- a/cekit/tools.py
+++ b/cekit/tools.py
@@ -362,7 +362,7 @@ def run_wrapper(
         stderr_capture = None
         if capture_output:
             stdout_capture = subprocess.PIPE
-            stderr_capture = subprocess.PIPE
+            stderr_capture = subprocess.STDOUT
         # subprocess.run uses Popen: https://docs.python.org/3/library/subprocess.html#subprocess.Popen
         # which uses https://docs.python.org/3/library/os.html#os.execvpe like behaviour
         # to locate the executable if its relative on POSIX.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -224,14 +224,14 @@ def test_osbs_builder_run_brew_stage(mocker):
         [
             call(
                 ["git", "config", "--get", "remote.origin.url"],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
             ),
             call(
                 ["git", "rev-parse", "HEAD"],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
@@ -245,7 +245,7 @@ def test_osbs_builder_run_brew_stage(mocker):
                     "--kwargs",
                     "{'src': 'git+https://something.redhat.com/git/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
                 ],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
@@ -283,14 +283,14 @@ def test_osbs_builder_run_brew(mocker):
         [
             call(
                 ["git", "config", "--get", "remote.origin.url"],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
             ),
             call(
                 ["git", "rev-parse", "HEAD"],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
@@ -304,7 +304,7 @@ def test_osbs_builder_run_brew(mocker):
                     "--kwargs",
                     "{'src': 'git+https://something.redhat.com/git/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
                 ],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
@@ -342,14 +342,14 @@ def test_osbs_builder_run_koji(mocker):
         [
             call(
                 ["git", "config", "--get", "remote.origin.url"],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
             ),
             call(
                 ["git", "rev-parse", "HEAD"],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
@@ -363,7 +363,7 @@ def test_osbs_builder_run_koji(mocker):
                     "--kwargs",
                     "{'src': 'git+https://something.redhat.com/git/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
                 ],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
@@ -435,7 +435,7 @@ def test_osbs_builder_run_brew_user(mocker):
             "--kwargs",
             "{'src': 'git+https://something.redhat.com/git/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-branch-containers-candidate', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
         ],
-        stderr=-1,
+        stderr=-2,
         stdout=-1,
         check=True,
         universal_newlines=True,
@@ -476,7 +476,7 @@ def test_osbs_builder_run_brew_target_defined_in_descriptor(mocker):
             "--kwargs",
             "{'src': 'git+https://something.redhat.com/git/containers/openjdk#c5a0731b558c8a247dd7f85b5f54462cd5b68b23', 'target': 'some-target', 'opts': {'scratch': True, 'git_branch': 'some-branch', 'yum_repourls': []}}",
         ],
-        stderr=-1,
+        stderr=-2,
         stdout=-1,
         check=True,
         universal_newlines=True,
@@ -514,7 +514,7 @@ def test_osbs_wait_for_osbs_task_finished_successfully(mocker):
 
     run.assert_called_with(
         ["brew", "call", "--json-output", "getTaskInfo", "12345"],
-        stderr=-1,
+        stderr=-2,
         stdout=-1,
         check=True,
         universal_newlines=True,
@@ -570,14 +570,14 @@ def test_osbs_wait_for_osbs_task_in_progress(mocker):
         [
             call(
                 ["brew", "call", "--json-output", "getTaskInfo", "12345"],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
             ),
             call(
                 ["brew", "call", "--json-output", "getTaskInfo", "12345"],
-                stderr=-1,
+                stderr=-2,
                 stdout=-1,
                 check=True,
                 universal_newlines=True,
@@ -622,7 +622,7 @@ def test_osbs_wait_for_osbs_task_failed(mocker):
 
     run.assert_called_with(
         ["brew", "call", "--json-output", "getTaskInfo", "12345"],
-        stderr=-1,
+        stderr=-2,
         stdout=-1,
         check=True,
         universal_newlines=True,
@@ -1046,7 +1046,7 @@ def test_podman_builder_run_with_generator(mocker):
     params = Map({"tags": []})
     run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
-    builder.generator = DockerGenerator("", "", "", {})
+    builder.generator = DockerGenerator("", "", "", {}, False)
     builder.generator.image = Image(
         yaml.safe_load(
             """
@@ -1088,7 +1088,7 @@ def test_buildah_builder_run_with_generator(mocker):
     params = Map({"tags": []})
     run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "buildah", params)
-    builder.generator = DockerGenerator("", "", "", {})
+    builder.generator = DockerGenerator("", "", "", {}, False)
     builder.generator.image = Image(
         yaml.safe_load(
             """
@@ -1177,7 +1177,7 @@ def test_podman_builder_with_squashing_disabled(mocker):
     params = {"no_squash": True}
     run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
-    builder.generator = DockerGenerator("", "", "", [])
+    builder.generator = DockerGenerator("", "", "", [], True)
     builder.generator.image = Image(
         yaml.safe_load(
             """
@@ -1210,7 +1210,7 @@ def test_podman_builder_with_build_arg(mocker):
     params = {"build_args": ["KEY=VALUE"]}
     run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
-    builder.generator = DockerGenerator("", "", "", [])
+    builder.generator = DockerGenerator("", "", "", [], False)
     builder.generator.image = Image(
         yaml.safe_load(
             """
@@ -1245,7 +1245,7 @@ def test_podman_builder_with_build_flag(mocker):
     params = {"build_flag": ["--compress"]}
     run = mocker.patch.object(subprocess, "run")
     builder = create_builder_object(mocker, "podman", params)
-    builder.generator = DockerGenerator("", "", "", [])
+    builder.generator = DockerGenerator("", "", "", [], False)
     builder.generator.image = Image(
         yaml.safe_load(
             """

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -800,7 +800,8 @@ def test_package_removal_and_install_and_reinstall(tmpdir):
         in dockerfile
     )
     assert (
-        """RUN rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"
+        """RUN dnf clean all \\
+    && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"
     """
         in dockerfile
     )

--- a/tests/test_integ_podman.py
+++ b/tests/test_integ_podman.py
@@ -2,30 +2,37 @@
 
 from __future__ import print_function
 
+import logging
 import os
 import shutil
+import sys
 
 from _pytest.capture import CaptureResult
 from click.testing import CliRunner
 
 from cekit.cli import cli
 from cekit.tools import Chdir
+from cekit.version import __version__
 
 
 def run_cekit(image_dir, args=None, env=None):
     if args is None:
-        args = ["build", "podman"]
+        args = ["-v", "build", "podman"]
 
     if env is None:
         env = {}
 
     with Chdir(image_dir):
+        print(f"Using image_dir={image_dir}")
         result = CliRunner(env=env).invoke(cli, args, catch_exceptions=False)
+        sys.stdout.write("\n")
+        sys.stdout.write(result.output)
         assert result.exit_code == 0
         return result
 
 
-def test_podman_builder_with_alpine_image(tmpdir):
+def test_podman_builder_with_alpine_image(tmpdir, caplog):
+    caplog.set_level(logging.DEBUG, logger="cekit")
     tmpdir = str(tmpdir)
 
     shutil.copytree(
@@ -36,6 +43,82 @@ def test_podman_builder_with_alpine_image(tmpdir):
     # The 'BUILDAH_LAYERS' environment variable is required to not cache intermediate layers
     # See: https://bugzilla.redhat.com/show_bug.cgi?id=1746022
     run_cekit(os.path.join(tmpdir, "alpine"), env={"BUILDAH_LAYERS": "false"})
+
+    print(f"#### Caplog {caplog.text} ####")
+    assert (
+        """STEP 11/12: RUN rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"
+"""
+        in caplog.text
+    )
+
+
+def test_podman_builder_with_alpine_image_and_no_squash(tmpdir, caplog):
+    caplog.set_level(logging.DEBUG, logger="cekit")
+    tmpdir = str(tmpdir)
+
+    shutil.copytree(
+        os.path.join(os.path.dirname(__file__), "images", "alpine"),
+        os.path.join(tmpdir, "alpine"),
+    )
+
+    # The 'BUILDAH_LAYERS' environment variable is required to not cache intermediate layers
+    # See: https://bugzilla.redhat.com/show_bug.cgi?id=1746022
+    run_cekit(
+        os.path.join(tmpdir, "alpine"),
+        env={"BUILDAH_LAYERS": "false"},
+        args=["-v", "build", "podman", "--no-squash"],
+    )
+    assert (
+        """STEP 5/11: RUN :         && apk  add python3             && apk info -e python3         && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"         && :"""
+        in caplog.text
+    )
+
+    with open(
+        os.path.join(str(tmpdir), "alpine/target/image/Containerfile"), "r"
+    ) as _file:
+        containerFile = _file.read()
+        assert (
+            """###### START module 'app:1.0'
+###### \\
+        # Copy 'app' module content
+        COPY modules/app /tmp/scripts/app
+        # Switch to 'root' user for package management for 'app' module defined packages
+        USER root
+        RUN : \\
+        # Install packages defined in the 'app' module
+        && apk  add python3 \\
+            && apk info -e python3 \\
+        # Clear package manager metadata
+        && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf" \\
+        && :
+
+        # Custom scripts from 'app' module
+        USER root
+        RUN [ "sh", "-x", "/tmp/scripts/app/install.sh" ]
+###### /
+###### END module 'app:1.0'
+
+###### START image 'cekit-alpine:1.0.0'
+###### \\
+        # Set 'cekit-alpine' image defined labels
+        LABEL \\
+            description="Some Alpine image" \\
+            io.cekit.version="VVVVV" \\
+            summary="Some Alpine image"
+###### /
+###### END image 'cekit-alpine:1.0.0'
+
+
+
+    # Switch to 'root' user and remove artifacts and modules
+    USER root
+    RUN rm -rf "/tmp/scripts" "/tmp/artifacts"
+    # Define the user
+    USER root""".replace(
+                "VVVVV", __version__
+            )
+            in containerFile
+        )
 
 
 def test_podman_from_scratch(tmpdir):

--- a/tests/test_integ_podman.py
+++ b/tests/test_integ_podman.py
@@ -46,7 +46,7 @@ def test_podman_builder_with_alpine_image(tmpdir, caplog):
 
     print(f"#### Caplog {caplog.text} ####")
     assert (
-        """STEP 11/12: RUN rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"
+        """STEP 11/12: RUN :     && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"
 """
         in caplog.text
     )
@@ -69,7 +69,7 @@ def test_podman_builder_with_alpine_image_and_no_squash(tmpdir, caplog):
         args=["-v", "build", "podman", "--no-squash"],
     )
     assert (
-        """STEP 5/11: RUN :         && apk  add python3             && apk info -e python3         && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"         && :"""
+        """STEP 5/11: RUN :         && apk  add python3             && apk info -e python3         && :         && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"         && :"""
         in caplog.text
     )
 
@@ -89,6 +89,7 @@ def test_podman_builder_with_alpine_image_and_no_squash(tmpdir, caplog):
         && apk  add python3 \\
             && apk info -e python3 \\
         # Clear package manager metadata
+        && : \\
         && rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf" \\
         && :
 

--- a/tests/test_unit_generator_docker.py
+++ b/tests/test_unit_generator_docker.py
@@ -73,7 +73,7 @@ def docker_generator(tmpdir, overrides=None):
 
     image_dir = str(tmpdir)
     target_dir = os.path.join(image_dir, "target")
-    yield DockerGenerator(image_dir, target_dir, "", overrides)
+    yield DockerGenerator(image_dir, target_dir, "", overrides, False)
 
 
 def setup_function():

--- a/tests/test_unit_tools.py
+++ b/tests/test_unit_tools.py
@@ -937,8 +937,8 @@ def test_run_wrapper_capture_error(tmpdir) -> None:
         result = run_wrapper(
             ["git", "rev-parse", "--is-inside-work-tree"], True, check=False
         )
-        assert result.stdout == ""
-        assert not result.stderr.endswith("\n")
+        assert result.stderr is None
+        assert not result.stdout.endswith("\n")
         assert result.returncode == 128
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -533,7 +533,7 @@ def test_override_add_module_and_packages_in_overrides(tmpdir):
 
     assert check_dockerfile(
         image_dir,
-        "RUN yum --setopt=tsflags=nodocs install -y package1 package2 \\",
+        "&& yum --setopt=tsflags=nodocs install -y package1 package2 \\",
         "Containerfile",
     )
     assert check_dockerfile(
@@ -574,8 +574,8 @@ def test_microdnf_clean_all_cmd_present(tmpdir):
     )
 
     required_matches = [
-        "RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y package1 package2 \\",
-        "&& microdnf clean all && rpm -q package1 package2",
+        "&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y package1 package2 \\",
+        "&& microdnf clean all && rpm -q package1 package2 \\",
     ]
 
     for match in required_matches:
@@ -585,6 +585,7 @@ def test_microdnf_clean_all_cmd_present(tmpdir):
 def check_dockerfile(image_dir, match, container_file="Dockerfile"):
     with open(os.path.join(image_dir, "target", "image", container_file), "r") as fd:
         for line in fd.readlines():
+            print(line)
             if line.strip() == match.strip():
                 return True
     return False
@@ -1206,7 +1207,7 @@ def test_override_modules_flat(tmpdir, mocker):
     run_cekit(image_dir)
 
     assert check_dockerfile_text(image_dir, 'foo="mod_2"')
-    assert not check_dockerfile_text(image_dir, "RUN yum clean all")
+    assert not check_dockerfile_text(image_dir, "&& yum clean all")
 
 
 def test_execution_order_flat(tmpdir, mocker):
@@ -1293,7 +1294,7 @@ def test_execution_order_flat(tmpdir, mocker):
 ###### END module 'mod_4:1.0'
 """
     assert check_dockerfile_text(image_dir, expected_modules_order)
-    assert not check_dockerfile_text(image_dir, "RUN yum clean all")
+    assert not check_dockerfile_text(image_dir, "&& yum clean all")
 
 
 def test_package_related_commands_packages_in_module(tmpdir, mocker):
@@ -1319,9 +1320,12 @@ def test_package_related_commands_packages_in_module(tmpdir, mocker):
 ###### \\
         # Switch to 'root' user for package management for 'packages_module' module defined packages
         USER root
+        RUN : \\
         # Install packages defined in the 'packages_module' module
-        RUN yum --setopt=tsflags=nodocs install -y kernel java-1.8.0-openjdk \\
-            && rpm -q kernel java-1.8.0-openjdk
+        && yum --setopt=tsflags=nodocs install -y kernel java-1.8.0-openjdk \\
+            && rpm -q kernel java-1.8.0-openjdk \\
+        && :
+
 ###### /
 ###### END module 'packages_module:1.0'
 
@@ -1329,9 +1333,12 @@ def test_package_related_commands_packages_in_module(tmpdir, mocker):
 ###### \\
         # Switch to 'root' user for package management for 'packages_module_1' module defined packages
         USER root
+        RUN : \\
         # Install packages defined in the 'packages_module_1' module
-        RUN yum --setopt=tsflags=nodocs install -y wget mc \\
-            && rpm -q wget mc
+        && yum --setopt=tsflags=nodocs install -y wget mc \\
+            && rpm -q wget mc \\
+        && :
+
 ###### /
 ###### END module 'packages_module_1:1.0'
 """
@@ -1364,10 +1371,10 @@ def test_package_related_commands_packages_in_image(tmpdir, caplog):
 
     expected_packages_install = """
         USER root
+        RUN : \\
         # Install packages defined in the 'test/image' image
-        RUN yum --setopt=tsflags=nodocs install -y wget mc \\
-            && rpm -q wget mc
-"""
+        && yum --setopt=tsflags=nodocs install -y wget mc \\
+            && rpm -q wget mc"""
 
     assert (
         "Required CEKit library 'odcs-client' was found as a 'odcs' module!"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -575,7 +575,8 @@ def test_microdnf_clean_all_cmd_present(tmpdir):
 
     required_matches = [
         "&& microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y package1 package2 \\",
-        "&& microdnf clean all && rpm -q package1 package2 \\",
+        "RUN microdnf clean all \\",
+        '&& rm -rf "/var/cache/yum" "/var/lib/dnf" "/var/cache/apt" "/var/cache/dnf"',
     ]
 
     for match in required_matches:
@@ -585,7 +586,6 @@ def test_microdnf_clean_all_cmd_present(tmpdir):
 def check_dockerfile(image_dir, match, container_file="Dockerfile"):
     with open(os.path.join(image_dir, "target", "image", container_file), "r") as fd:
         for line in fd.readlines():
-            print(line)
             if line.strip() == match.strip():
                 return True
     return False


### PR DESCRIPTION
Essentially if CEKit squashing is disabled this then moves the packagement management clean next to the package install/remove/etc commands - this reduces the layers and ensures caches are not left lying around.

Fixes #849
This will also reduce the number of layers as mentioned in #593 